### PR TITLE
⬆️  Update Script Runner Test Dependency

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,6 @@ def tests(session: Session) -> None:
         run_install = False
         session.posargs.remove("skip-install")
     if run_install:
-        session.install("numpy")
         session.install("-e", ".[test]")
     session.run("pytest", *session.posargs)
 
@@ -46,7 +45,6 @@ def coverage(session: Session) -> None:
         run_install = False
         session.posargs.remove("skip-install")
     if run_install:
-        session.install("numpy")
         session.install("-e", ".[coverage]")
     session.run("pytest", "--cov", *session.posargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest>=7.2", "pytest-console-scripts>=1.3", "pytest-mock"]
+test = ["pytest>=7.2", "pytest-console-scripts>=1.4", "pytest-mock"]
 coverage = ["mqt.qecc[test]", "pytest-cov"]
 docs = [
     "sphinx>=5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,8 @@ dependencies = [
     "qecsim",
     "ldpc>=0.1.50",
     "numpy",
-    # temporary workaround for a deprecation warning within qiskit-aer<=0.12.0 in combination with qiskit-terra>=0.24.0
-    # once qiskit-aer>=0.12.1 is released, this can be removed completely
-    # this should be triggered automatically by dependabot
-    "qiskit-terra>=0.23.0,<0.24.0",
-    "qiskit-aer>=0.12.0,<0.12.3",
+    "qiskit-terra>=0.23.0",
+    "qiskit-aer>=0.12.1,<0.12.3",
 ]
 dynamic = ["version"]
 
@@ -120,8 +117,6 @@ addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
 log_cli_level = "INFO"
 xfail_strict = true
 filterwarnings = ["error", "ignore:pkg_resources.*:DeprecationWarning:"]
-
-
 
 [tool.coverage.run]
 source = ["mqt.qecc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "ldpc>=0.1.50",
     "numpy",
     "qiskit-terra>=0.23.0",
-    "qiskit-aer>=0.12.1,<0.12.3",
+    "qiskit-aer>=0.12.1",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,9 +119,7 @@ testpaths = ["test/python"]
 addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
 log_cli_level = "INFO"
 xfail_strict = true
-filterwarnings = ["error",
-    "ignore::DeprecationWarning:pkg_resources.*"
-]
+filterwarnings = ["error", "ignore:pkg_resources.*:DeprecationWarning:"]
 
 
 


### PR DESCRIPTION
## Description

This small PR updates the pytest script runner test dependency lower cap.
This also removes the (now superfluous) upper cap on `qiskit-terra` that has been put in place until the release of `qiskit_aer==0.12.1`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
