### PR TITLE
update pybind version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 BUILD_REQUIREMENTS = [
     "scikit-build-core[pyproject]>=0.6.1",
     "setuptools_scm>=7",
-    "pybind11>=2.11",
+    "pybind11>=2.12",
 ]
 
 if os.environ.get("CI", None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.6.1", "setuptools-scm>=7", "pybind11>=2.11"]
+requires = ["scikit-build-core>=0.6.1", "setuptools-scm>=7", "pybind11>=2.12"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -1,6 +1,6 @@
 scikit-build-core==0.6.1
 setuptools-scm==7.0.0
-pybind11==2.11.0
+pybind11==2.12.0
 pytest==7.0.0
 pytest-console-scripts==1.4
 z3-solver~=4.11.0


### PR DESCRIPTION
## Description
This PR updates the minimum `pybind11` version to 2.12, which was released a couple weeks ago and brings several big improvements, including compatibility with Numpy 2.0 which will be released soon, see https://github.com/cda-tum/mqt-qcec/pull/383

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
