### PR TITLE
👷🏼 fix and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-13, macos-14]
+        runs-on: [macos-13]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
 
   cpp-tests-macos:
     name: 🍎 Release
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos-13, macos-14]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,7 +60,7 @@ jobs:
         uses: Chocobo1/setup-ccache-action@v1
         with:
           prepend_symlinks_to_path: false
-          override_cache_key: c++-tests-macos-latest
+          override_cache_key: c++-tests-macos-13
       - name: Install Ninja
         run: pipx install ninja
       - if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CMAKE_BUILD_PARALLEL_LEVEL: 3
-  CTEST_PARALLEL_LEVEL: 3
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_PARALLEL_LEVEL: 4
 
 defaults:
   run:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-11]
+        runs-on: [ubuntu-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-13, macos-14]
+        runs-on: [ubuntu-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,14 +22,14 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - runs-on: macos-13
             python-version: 3.8
           - runs-on: macos-13
-            python-version: 3.12
+            python-version: 3.11
           - runs-on: macos-14
-            python-version: 3.12
+            python-version: 3.11
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -28,8 +28,6 @@ jobs:
             python-version: 3.8
           - runs-on: macos-13
             python-version: 3.11
-          - runs-on: macos-14
-            python-version: 3.11
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - runs-on: macos-13
             python-version: 3.8
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,10 +24,12 @@ jobs:
         runs-on: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: 3.8
-          - runs-on: macos-latest
-            python-version: 3.11
+          - runs-on: macos-13
+            python-version: 3.12
+          - runs-on: macos-14
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,7 +50,7 @@ jobs:
         if: matrix.runs-on == 'ubuntu-latest'
         run: sudo apt-get install libflint-dev
       - name: Install flint (macOS)
-        if: matrix.runs-on == 'macos-latest'
+        if: runner.os == 'macOS'
         run: |
           brew install gmp mpfr ntl
           git clone --branch v2.9.0 --depth 1 https://github.com/flintlib/flint2.git


### PR DESCRIPTION
## Description

GitHub's latest rollout of macOS-14 (which uses Apple Silicon hardware) as macOS-latest has broken the CI pipelines here.
This PR fixes the workflows and updates the configuration a little bit.
This should become much easier once this repository no longer depends on the flint package because then the reusable MQT workflows can be used.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
