### PR TITLE
Restrict numpy to version < 2.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "z3-solver>=4.11,<4.14",
     "qecsim",
     "ldpc>=0.1.50",
-    "numpy < 2",
+    "numpy < 2",  # some of our dependencies are not yet compatible with numpy 2.0
     "qiskit[qasm3-import]>=1.0.0",
     "qiskit-aer>=0.14.0",
     "bposd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "z3-solver>=4.11,<4.14",
     "qecsim",
     "ldpc>=0.1.50",
-    "numpy",
+    "numpy < 2",
     "qiskit[qasm3-import]>=1.0.0",
     "qiskit-aer>=0.14.0",
     "bposd",


### PR DESCRIPTION
## Description

New numpy version break binary compatibility with Cython. For now we restrict numpy version until this issue is fixed.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
