### PR TITLE
🔧👷 properly exclude `build` directory from CodeQL

### DIFF
--- a/.github/workflows/reusable-code-ql.yml
+++ b/.github/workflows/reusable-code-ql.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           patterns: |
             -**/extern/**
+            -**/build/**
           input: sarif-results/${{ matrix.language }}.sarif
           output: sarif-results/${{ matrix.language }}.sarif
 


### PR DESCRIPTION
## Description

This small PR adjusts the CodeQL config to ignore the `build` folder. Since the introduction of using `FetchContent`, the build folder also contains a `_deps` subfolder with all the fetched dependencies. These might (and in the case of QECC here, will) trigger CodeQL warnings we have no control over.
This PR should reduce the number of warnings flagged for the project.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
