### PR TITLE
Fix small code bugs for FT Stateprep

### DIFF
--- a/src/mqt/qecc/ft_stateprep/state_prep.py
+++ b/src/mqt/qecc/ft_stateprep/state_prep.py
@@ -52,7 +52,7 @@ class StatePrepCircuit:
         self.z_checks = code.Hz.copy() if not zero_state else np.vstack((code.Lz.copy(), code.Hz.copy()))
 
         self.num_qubits = circ.num_qubits
-        self.max_errors = (code.distance - 1) // 2
+        self.max_errors = code.distance // 2
         self.x_fault_sets = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
         self.z_fault_sets = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
         self.x_fault_sets_unreduced = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
@@ -567,7 +567,7 @@ def gate_optimal_verification_stabilizers(
     Returns:
         A list of stabilizers to verify the state preparation circuit.
     """
-    max_errors = (sp_circ.code.distance - 1) // 2
+    max_errors = (sp_circ.code.distance) // 2
     layers = [[] for _ in range(max_errors)]  # type: list[list[npt.NDArray[np.int8]]]
     if max_ancillas is None:
         max_ancillas = sp_circ.max_z_measurements if x_errors else sp_circ.max_x_measurements
@@ -769,7 +769,7 @@ def heuristic_verification_stabilizers(
         additional_faults: Faults to verify in addition to the faults propagating in the state preparation circuit.
     """
     logging.info("Finding verification stabilizers using heuristic method")
-    max_errors = (sp_circ.code.distance - 1) // 2
+    max_errors = (sp_circ.code.distance) // 2
     layers = [[] for _ in range(max_errors)]  # type: list[list[npt.NDArray[np.int8]]]
     sp_circ.compute_fault_sets()
     fault_sets = (
@@ -950,13 +950,13 @@ def _measure_ft_stabs(
     measured_circ.compose(sp_circ.circ, inplace=True)
 
     if sp_circ.zero_state:
-        _measure_ft_z(measured_circ, z_measurements, t=(sp_circ.code.x_distance - 1) // 2)
+        _measure_ft_z(measured_circ, z_measurements, t=(sp_circ.code.x_distance) // 2)
         if full_fault_tolerance:
-            _measure_ft_x(measured_circ, x_measurements, flags=True, t=(sp_circ.code.x_distance - 1) // 2)
+            _measure_ft_x(measured_circ, x_measurements, flags=True, t=(sp_circ.code.x_distance) // 2)
     else:
-        _measure_ft_x(measured_circ, x_measurements, t=(sp_circ.code.z_distance - 1) // 2)
+        _measure_ft_x(measured_circ, x_measurements, t=(sp_circ.code.z_distance) // 2)
         if full_fault_tolerance:
-            _measure_ft_z(measured_circ, z_measurements, flags=True, t=(sp_circ.code.z_distance - 1) // 2)
+            _measure_ft_z(measured_circ, z_measurements, flags=True, t=(sp_circ.code.z_distance) // 2)
 
     return measured_circ
 
@@ -1182,8 +1182,8 @@ def _remove_trivial_faults(
     faults = faults.copy()
     logging.info("Removing trivial faults.")
     d_error = code.x_distance if x_errors else code.z_distance
-    t_error = (d_error - 1) // 2
-    t = (code.distance - 1) // 2
+    t_error = (d_error) // 2
+    t = (code.distance) // 2
     max_w = t_error // t
     for i, fault in enumerate(faults):
         faults[i] = _coset_leader(fault, stabs)
@@ -1234,7 +1234,7 @@ def naive_verification_circuit(sp_circ: StatePrepCircuit) -> QuantumCircuit:
 
     z_measurements = list(sp_circ.code.Hx)
     x_measurements = list(sp_circ.code.Hz)
-    reps = (sp_circ.code.distance - 1) // 2
+    reps = sp_circ.code.distance // 2
     return _measure_ft_stabs(sp_circ, z_measurements * reps, x_measurements * reps)
 
 

--- a/src/mqt/qecc/ft_stateprep/state_prep.py
+++ b/src/mqt/qecc/ft_stateprep/state_prep.py
@@ -52,7 +52,7 @@ class StatePrepCircuit:
         self.z_checks = code.Hz.copy() if not zero_state else np.vstack((code.Lz.copy(), code.Hz.copy()))
 
         self.num_qubits = circ.num_qubits
-        self.max_errors = code.distance // 2
+        self.max_errors = (code.distance - 1) // 2
         self.x_fault_sets = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
         self.z_fault_sets = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
         self.x_fault_sets_unreduced = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
@@ -567,7 +567,7 @@ def gate_optimal_verification_stabilizers(
     Returns:
         A list of stabilizers to verify the state preparation circuit.
     """
-    max_errors = (sp_circ.code.distance) // 2
+    max_errors = (sp_circ.code.distance - 1) // 2
     layers = [[] for _ in range(max_errors)]  # type: list[list[npt.NDArray[np.int8]]]
     if max_ancillas is None:
         max_ancillas = sp_circ.max_z_measurements if x_errors else sp_circ.max_x_measurements
@@ -769,7 +769,7 @@ def heuristic_verification_stabilizers(
         additional_faults: Faults to verify in addition to the faults propagating in the state preparation circuit.
     """
     logging.info("Finding verification stabilizers using heuristic method")
-    max_errors = (sp_circ.code.distance) // 2
+    max_errors = (sp_circ.code.distance - 1) // 2
     layers = [[] for _ in range(max_errors)]  # type: list[list[npt.NDArray[np.int8]]]
     sp_circ.compute_fault_sets()
     fault_sets = (
@@ -950,13 +950,13 @@ def _measure_ft_stabs(
     measured_circ.compose(sp_circ.circ, inplace=True)
 
     if sp_circ.zero_state:
-        _measure_ft_z(measured_circ, z_measurements, t=(sp_circ.code.x_distance) // 2)
+        _measure_ft_z(measured_circ, z_measurements, t=(sp_circ.code.x_distance - 1) // 2)
         if full_fault_tolerance:
-            _measure_ft_x(measured_circ, x_measurements, flags=True, t=(sp_circ.code.x_distance) // 2)
+            _measure_ft_x(measured_circ, x_measurements, flags=True, t=(sp_circ.code.x_distance - 1) // 2)
     else:
-        _measure_ft_x(measured_circ, x_measurements, t=(sp_circ.code.z_distance) // 2)
+        _measure_ft_x(measured_circ, x_measurements, t=(sp_circ.code.z_distance - 1) // 2)
         if full_fault_tolerance:
-            _measure_ft_z(measured_circ, z_measurements, flags=True, t=(sp_circ.code.z_distance) // 2)
+            _measure_ft_z(measured_circ, z_measurements, flags=True, t=(sp_circ.code.z_distance - 1) // 2)
 
     return measured_circ
 
@@ -1182,8 +1182,8 @@ def _remove_trivial_faults(
     faults = faults.copy()
     logging.info("Removing trivial faults.")
     d_error = code.x_distance if x_errors else code.z_distance
-    t_error = (d_error) // 2
-    t = (code.distance) // 2
+    t_error = (d_error - 1) // 2
+    t = (code.distance - 1) // 2
     max_w = t_error // t
     for i, fault in enumerate(faults):
         faults[i] = _coset_leader(fault, stabs)
@@ -1234,7 +1234,7 @@ def naive_verification_circuit(sp_circ: StatePrepCircuit) -> QuantumCircuit:
 
     z_measurements = list(sp_circ.code.Hx)
     x_measurements = list(sp_circ.code.Hz)
-    reps = sp_circ.code.distance // 2
+    reps = (sp_circ.code.distance - 1) // 2
     return _measure_ft_stabs(sp_circ, z_measurements * reps, x_measurements * reps)
 
 

--- a/src/mqt/qecc/ft_stateprep/state_prep.py
+++ b/src/mqt/qecc/ft_stateprep/state_prep.py
@@ -56,7 +56,7 @@ class StatePrepCircuit:
 
         self.num_qubits = circ.num_qubits
 
-        self.error_detection = error_detection_code
+        self.error_detection_code = error_detection_code
         self._set_max_errors()
 
         self.max_x_measurements = len(self.x_checks)
@@ -64,7 +64,7 @@ class StatePrepCircuit:
 
     def set_error_detection(self, error_detection: bool) -> None:
         """Set whether the state preparation circuit is for error detection."""
-        self.error_detection = error_detection
+        self.error_detection_code = error_detection
         self._set_max_errors()
 
     def compute_fault_sets(self, reduce: bool = True) -> None:
@@ -178,11 +178,16 @@ class StatePrepCircuit:
 
     def _set_max_errors(self) -> None:
         if self.code.distance == 2:
-            error_detection_code = True
+            logging.warning("Code distance is 2, assuming error detection code.")
+            self.error_detection_code = True
 
-        self.max_errors = (self.code.distance - 1) // 2 if not error_detection_code else self.code.distance // 2
-        self.max_x_errors = (self.code.x_distance - 1) // 2 if not error_detection_code else self.code.x_distance // 2
-        self.max_z_errors = (self.code.z_distance - 1) // 2 if not error_detection_code else self.code.z_distance // 2
+        self.max_errors = (self.code.distance - 1) // 2 if not self.error_detection_code else self.code.distance // 2
+        self.max_x_errors = (
+            (self.code.x_distance - 1) // 2 if not self.error_detection_code else self.code.x_distance // 2
+        )
+        self.max_z_errors = (
+            (self.code.z_distance - 1) // 2 if not self.error_detection_code else self.code.z_distance // 2
+        )
         self.x_fault_sets = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
         self.z_fault_sets = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]
         self.x_fault_sets_unreduced = [None for _ in range(self.max_errors + 1)]  # type: list[npt.NDArray[np.int8] | None]

--- a/test/python/ft_stateprep/test_stateprep.py
+++ b/test/python/ft_stateprep/test_stateprep.py
@@ -460,4 +460,3 @@ def test_error_detection_code() -> None:
 
     assert circ_ver_detection.num_qubits > circ_ver_correction.num_qubits
     assert circ_ver_detection.num_nonlocal_gates() > circ_ver_correction.num_nonlocal_gates()
-    assert circ_ver_detection.depth() > circ_ver_correction.depth()

--- a/test/python/ft_stateprep/test_stateprep.py
+++ b/test/python/ft_stateprep/test_stateprep.py
@@ -35,6 +35,18 @@ def steane_code() -> CSSCode:
 
 
 @pytest.fixture
+def css_4_2_2_code() -> CSSCode:
+    """Return the 4,2,2  code."""
+    return CSSCode(2, np.array([[1] * 4]), np.array([[1] * 4]))
+
+
+@pytest.fixture
+def css_6_2_2_code() -> CSSCode:
+    """Return the 4,2,2  code."""
+    return CSSCode(2, np.array([[1] * 6]), np.array([[1] * 6]))
+
+
+@pytest.fixture
 def surface_code() -> CSSCode:
     """Return the distance 3 rotated Surface Code."""
     return CSSCode.from_code_name("surface", 3)
@@ -96,10 +108,12 @@ def get_stabs(qc: QuantumCircuit) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.
     return x, z
 
 
-@pytest.mark.parametrize("code_name", ["steane", "tetrahedral", "surface"])
-def test_heuristic_prep_consistent(code_name: str) -> None:
+@pytest.mark.parametrize(
+    "code", ["steane_code", "css_4_2_2_code", "css_6_2_2_code", "tetrahedral_code", "surface_code"]
+)
+def test_heuristic_prep_consistent(code: CSSCode, request) -> None:  # type: ignore[no-untyped-def]
     """Check that heuristic_prep_circuit returns a valid circuit with the correct stabilizers."""
-    code = CSSCode.from_code_name(code_name)
+    code = request.getfixturevalue(code)
 
     sp_circ = heuristic_prep_circuit(code)
     circ = sp_circ.circ
@@ -113,7 +127,7 @@ def test_heuristic_prep_consistent(code_name: str) -> None:
     assert eq_span(np.vstack((code.Hz, code.Lz)), z)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("code", ["steane_code"])
+@pytest.mark.parametrize("code", ["steane_code", "css_4_2_2_code", "css_6_2_2_code"])
 def test_gate_optimal_prep_consistent(code: CSSCode, request) -> None:  # type: ignore[no-untyped-def]
     """Check that gate_optimal_prep_circuit returns a valid circuit with the correct stabilizers."""
     code = request.getfixturevalue(code)
@@ -132,7 +146,7 @@ def test_gate_optimal_prep_consistent(code: CSSCode, request) -> None:  # type: 
     assert eq_span(np.vstack((code.Hz, code.Lz)), z)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("code", ["steane_code"])
+@pytest.mark.parametrize("code", ["steane_code", "css_4_2_2_code", "css_6_2_2_code"])
 def test_depth_optimal_prep_consistent(code: CSSCode, request) -> None:  # type: ignore[no-untyped-def]
     """Check that depth_optimal_prep_circuit returns a valid circuit with the correct stabilizers."""
     code = request.getfixturevalue(code)
@@ -150,7 +164,7 @@ def test_depth_optimal_prep_consistent(code: CSSCode, request) -> None:  # type:
     assert eq_span(np.vstack((code.Hz, code.Lz)), z)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("code", ["steane_code"])
+@pytest.mark.parametrize("code", ["steane_code", "css_4_2_2_code", "css_6_2_2_code"])
 def test_plus_state_gate_optimal(code: CSSCode, request) -> None:  # type: ignore[no-untyped-def]
     """Test synthesis of the plus state."""
     code = request.getfixturevalue(code)
@@ -184,7 +198,9 @@ def test_plus_state_gate_optimal(code: CSSCode, request) -> None:  # type: ignor
         assert not np.array_equal(z, x_zero)
 
 
-@pytest.mark.parametrize("code", ["steane_code", "surface_code", "tetrahedral_code"])
+@pytest.mark.parametrize(
+    "code", ["steane_code", "css_4_2_2_code", "css_6_2_2_code", "surface_code", "tetrahedral_code"]
+)
 def test_plus_state_heuristic(code: CSSCode, request) -> None:  # type: ignore[no-untyped-def]
     """Test synthesis of the plus state."""
     code = request.getfixturevalue(code)
@@ -426,3 +442,22 @@ def test_full_ft_heuristic_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     circ_ver_x_ft = heuristic_verification_circuit(circ, full_fault_tolerance=False)
     assert circ_ver_full_ft.num_nonlocal_gates() > circ_ver_x_ft.num_nonlocal_gates()
     assert circ_ver_full_ft.depth() > circ_ver_x_ft.depth()
+
+
+def test_error_detection_code() -> None:
+    """Test that different circuits are obtained when using an error detection code."""
+    code = CSSCode.from_code_name("carbon")
+    circ = heuristic_prep_circuit(code)
+
+    circ_ver_correction = gate_optimal_verification_circuit(
+        circ, max_ancillas=3, max_timeout=5, full_fault_tolerance=False
+    )
+
+    circ.set_error_detection(True)
+    circ_ver_detection = gate_optimal_verification_circuit(
+        circ, max_ancillas=3, max_timeout=5, full_fault_tolerance=False
+    )
+
+    assert circ_ver_detection.num_qubits > circ_ver_correction.num_qubits
+    assert circ_ver_detection.num_nonlocal_gates() > circ_ver_correction.num_nonlocal_gates()
+    assert circ_ver_detection.depth() > circ_ver_correction.depth()


### PR DESCRIPTION
## Description

This PR fixes some issues with certain codes. 

There was a bug when the code was defined over a number of qubits, which is an exact power of 2, leading to the optimal state prep circuit failing to be synthesized.

Another issue occurred when looking at d=2 codes, which cannot be used for error correction but only for error detection. I have added functionality to set whether one wants to create the circuit for error detection or error correction in the `StatePrepCircuit` class.

Fixes #265

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
