### PR TITLE
⬆️ update ldpc with numpy 2 and Python 3.12+ support

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -22,29 +22,6 @@ jobs:
         with:
           prepend_symlinks_to_path: false
           override_cache_key: wheels-${{ matrix.runs-on }}
-      - if: runner.os == 'macOS'
-        name: Install gmp from source
-        run: |
-          curl -L https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz | tar xJ
-          cd gmp-6.3.0
-          export CC="ccache clang"
-          export CXX="ccache clang++"
-          export MACOSX_DEPLOYMENT_TARGET=11.0
-          ./configure --enable-cxx --prefix=/usr/local
-          make -j 4 && sudo make install
-          echo GMP_ROOT="/usr/local" >> $GITHUB_ENV
-      - if: runner.os == 'macOS'
-        name: Install mpfr from source
-        run: |
-          curl -L https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.xz | tar xJ
-          cd mpfr-4.2.1
-          export CC="ccache clang"
-          export CXX="ccache clang++"
-          export MACOSX_DEPLOYMENT_TARGET=11.0
-          # use the GMP install from above
-          ./configure --prefix=/usr/local --with-gmp=/usr/local
-          make -j 4 && sudo make install
-          echo MPFR_ROOT="/usr/local" >> $GITHUB_ENV
       # set up uv for faster Python package management
       - if: runner.os == 'macOS'
         uses: yezz123/setup-uv@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,8 +30,6 @@ BUILD_REQUIREMENTS = [
     "setuptools_scm>=7",
     "pybind11>=2.13",
     "wheel>=0.40",  # transitive dependency of pytest on Windows
-    "Cython>=3; python_version > '3.11'",  # required to build ldpc on Python 3.12+
-    "numpy>=1.26,<2; python_version > '3.11'",  # required to build ldpc on Python 3.12+
 ]
 
 if os.environ.get("CI", None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,9 @@ requires-python = ">=3.9"
 dependencies = [
     "z3-solver>=4.12,<4.14",
     "qecsim",
-    "ldpc>=0.1.51",
-    "numpy>=1.26,<2; python_version > '3.11'", # some of our dependencies are not yet compatible with numpy 2.0
-    "numpy>=1.24,<2; python_version <= '3.11'", # some of our dependencies are not yet compatible with numpy 2.0
+    "ldpc>=0.1.53",
+    "numpy>=1.26; python_version > '3.11'",
+    "numpy>=1.24; python_version <= '3.11'",
     "qiskit[qasm3-import]>=1.0.0",
     "qiskit-aer>=0.15.0",
     "stim >= 1.13.0",
@@ -151,8 +151,6 @@ filterwarnings = [
     "ignore:.*pkg_resources.*:DeprecationWarning:",
     "ignore:.*The retworkx package is deprecated*:DeprecationWarning:pymatching",
     'ignore:.*qiskit.providers.provider.Provider.*:DeprecationWarning:',
-    'ignore:.*invalid escape sequence.*:DeprecationWarning:',
-    'ignore:.*invalid escape sequence.*:SyntaxWarning:',
 ]
 
 [tool.coverage]
@@ -305,11 +303,3 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 before-build = "uv pip install delvewheel>=1.7.3"
 repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_ARGS = "-T ClangCL", SKBUILD_CMAKE_ARGS="--fresh" }
-
-[[tool.cibuildwheel.overrides]]
-select = "cp312-*"
-# the following should allow to actually build the ldpc package for the tests on Python 3.12
-before-test = [
-  "uv pip install 'numpy<2' Cython setuptools wheel",
-  "uv pip install ldpc --no-build-isolation"
-]


### PR DESCRIPTION
## Description

This PR updates the ldpc dependency to its latest version, which brings compatibility with numpy 2.0 and ships Python 3.12 (as well as 3.13) wheels.
In addition, the new version contains a fix for the invalid escape sequence that was triggering test errors and had to be excluded.

This allows to remove quite some workarounds and streamlines the installation process of QECC.

Fixes #264 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
