### PR TITLE
Add representation for general stabilizer codes to the python side.

### DIFF
--- a/src/mqt/qecc/__init__.py
+++ b/src/mqt/qecc/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from ._version import version as __version__
 from .analog_information_decoding.simulators.analog_tannergraph_decoding import AnalogTannergraphDecoder, AtdSimulator
 from .analog_information_decoding.simulators.quasi_single_shot_v2 import QssSimulator
-from .codes import CSSCode, InvalidCSSCodeError
+from .codes import CSSCode, InvalidCSSCodeError, StabilizerCode
 from .pyqecc import (
     Code,
     Decoder,
@@ -37,6 +37,7 @@ __all__ = [
     "InvalidCSSCodeError",
     # "SoftInfoDecoder",
     "QssSimulator",
+    "StabilizerCode",
     "UFDecoder",
     "UFHeuristic",
     "__version__",

--- a/src/mqt/qecc/codes/__init__.py
+++ b/src/mqt/qecc/codes/__init__.py
@@ -7,6 +7,7 @@ from .color_code import ColorCode, LatticeType
 from .css_code import CSSCode, InvalidCSSCodeError
 from .hexagonal_color_code import HexagonalColorCode
 from .square_octagon_color_code import SquareOctagonColorCode
+from .stabilizer_code import StabilizerCode
 
 __all__ = [
     "CSSCode",
@@ -15,5 +16,6 @@ __all__ = [
     "InvalidCSSCodeError",
     "LatticeType",
     "SquareOctagonColorCode",
+    "StabilizerCode",
     "construct_bb_code",
 ]


### PR DESCRIPTION
## Description

Currently QECC only has support for CSS codes. This PR adds general stabilizer codes and reactors the current classes to reflect this structure.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
