### PR TITLE
📌 temporary `ldpc<2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ requires-python = ">=3.9"
 dependencies = [
     "z3-solver>=4.12",
     "qecsim",
-    "ldpc>=0.1.53",
+    "ldpc>=0.1.53,<2",  # temporary upper cap due to failures seen with ldpc v2
     "numpy>=1.26; python_version > '3.11'",
     "numpy>=1.24; python_version <= '3.11'",
     "qiskit[qasm3-import]>=1.0.0",


### PR DESCRIPTION
## Description

This PR temporarily pins the ldpc package to `<2` as the new version has broken QECC.
This is just meant as a quick fix until we ensured compatibility with `v2`

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
