### PR TITLE
📝 Fixed wrong links in documentation

### DIFF
--- a/docs/StatePrep.ipynb
+++ b/docs/StatePrep.ipynb
@@ -412,7 +412,7 @@
    "source": [
     "# Circuits and Evaluations\n",
     "\n",
-    "The circuits and benchmark scripts used for our non-deterministic work https://arxiv.org/abs/2408.11894, can be found [here](https://github.com/cda-tum/mqt-qecc/tree/main/src/mqt/qecc/ft_stateprep/eval) and for the deterministic work [here](https://github.com/cda-tum/mqt-qecc/tree/main/src/mqt/qecc/ft_stateprep/eval_det)."
+    "The circuits and benchmark scripts used for our non-deterministic work https://arxiv.org/abs/2408.11894, can be found [here](https://github.com/cda-tum/mqt-qecc/tree/main/scripts/ft_stateprep/eval) and for the deterministic work [here](https://github.com/cda-tum/mqt-qecc/tree/main/scripts/ft_stateprep/eval_det)."
    ]
   }
  ],


### PR DESCRIPTION
## Description

Because we moved the files in the det. PR links in the documentation were no longer valid.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
