### PR TITLE
Fixed documentation typo regarding the number of CNOT gates for the steane code

### DIFF
--- a/docs/StatePrep.ipynb
+++ b/docs/StatePrep.ipynb
@@ -57,7 +57,7 @@
    "id": "a648f3c7-1002-423d-99b9-f4d15b0d4cc3",
    "metadata": {},
    "source": [
-    "We see that the minimal number of CNOTs required to prepare the logical $|0\\rangle_L$ circuit of the Steane code is $7$.\n",
+    "We see that the minimal number of CNOTs required to prepare the logical $|0\\rangle_L$ circuit of the Steane code is $8$.\n",
     "\n",
     "## Synthesizing FT state preparation circuits\n",
     "The circuit above is not fault-tolerant. For example, an $X$ error on qubit $q_1$ before the last CNOT propagates to a weight $2$ X error on $q_1$ and $q_2$. This is to be expected since we apply two-qubit gates between the qubits of a single logical qubit. \n",


### PR DESCRIPTION
## Description

Fixed type regarding the number of CNOT gates for the steane code

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
