### PR TITLE
Set the `fault_tolerant` flag in the qsample protocol.

### DIFF
--- a/src/mqt/qecc/circuit_synthesis/simulation_det.py
+++ b/src/mqt/qecc/circuit_synthesis/simulation_det.py
@@ -118,7 +118,7 @@ class NoisyDFTStatePrepSimulator:
             self.decoder.generate_z_lut()
 
         # create protocol
-        self.protocol = qs.Protocol()
+        self.protocol = qs.Protocol(fault_tolerant=True)
         self._create_det_protocol(state_prep_circuit, verifications, code)
 
     def _create_det_protocol(


### PR DESCRIPTION
## Description

This PR fixes a minor problem in the simulation of deterministic state preparation circuits. qsample protocols need to be flagged whether they are fault-tolerant or not at construction to ensure that bounds are correctly computed. This PR sets this flag.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
