### PR TITLE
Fix setuptools version problem.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
   "qsample>=0.0.2",
   "urllib3>=2.3.0", # Required by qsample (to be removed)
   "fastcore>=1.8.1", # Required by qsample (to be removed)
+  "setuptools<81", # Version cap required by qsample (to be removed)
 ]
 dynamic = ["version"]
 
@@ -230,6 +231,7 @@ wille = "wille"
 ser = "ser"
 aer = "aer"
 anc = "anc"
+arange = "arange"
 
 
 [tool.repo-review]


### PR DESCRIPTION
## Description

Currently, the CI is failing everywhere because of a deprecated API used by the qsample dependency. This PR fixes this issue.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
