### PR TITLE
Add composition of multiple STIM circuits with defined alignment

### DIFF
--- a/src/mqt/qecc/circuit_synthesis/circuit_utils.py
+++ b/src/mqt/qecc/circuit_synthesis/circuit_utils.py
@@ -73,7 +73,9 @@ def compact_stim_circuit(circ: Circuit, scheduling_method: str = "asap") -> Circ
     """Move circuit instructions to the front and ignore TICKS.
 
     Args:
-         circ: stim circuit to compact
+        circ: stim circuit to compact
+        scheduling_method: Either "asap" (as soon as possible) or "alap" (as late as possible).
+
     Returns:
          A compacted stim circuit.
     """
@@ -83,9 +85,7 @@ def compact_stim_circuit(circ: Circuit, scheduling_method: str = "asap") -> Circ
     return compact_circ
 
 
-def compose_compact_stim_circuits(
-    circs: list[Circuit], align: str = "start"
-) -> Circuit:
+def compose_compact_stim_circuits(circs: list[Circuit], align: str = "start") -> Circuit:
     """Compose and compact multiple stim circuits.
 
     Args:
@@ -95,8 +95,9 @@ def compose_compact_stim_circuits(
     Returns:
         A composed and compacted stim circuit.
     """
-    if align not in ("start", "end"):
-        raise ValueError("align must be 'start' or 'end'.")
+    if align not in {"start", "end"}:
+        msg = "align must be 'start' or 'end'."
+        raise ValueError(msg)
 
     composed_layers: list[Circuit] = []
     for circ in circs:
@@ -110,7 +111,7 @@ def compose_compact_stim_circuits(
                 composed_layers.append(layer_circ)
 
     if align == "end":
-        composed_layers = composed_layers[::-1]
+        composed_layers.reverse()
 
     compose_circ = Circuit()
     for layer in composed_layers:
@@ -118,9 +119,7 @@ def compose_compact_stim_circuits(
     return compose_circ
 
 
-def collect_circuit_layers(
-    circ: Circuit, scheduling_method: str = "asap"
-) -> list[Circuit]:
+def collect_circuit_layers(circ: Circuit, scheduling_method: str = "asap") -> list[Circuit]:
     """Collect all layers that can be executed in parallel.
 
     Args:
@@ -130,8 +129,9 @@ def collect_circuit_layers(
     Returns:
         list of circuit layers. All instructions in one layer can be executed in parallel. It holds that circ=sum(collect_circuit_layers(circ)).
     """
-    if scheduling_method not in ("asap", "alap"):
-        raise ValueError("scheduling_method must be 'asap' or 'alap'.")
+    if scheduling_method not in {"asap", "alap"}:
+        msg = "scheduling_method must be 'asap' or 'alap'."
+        raise ValueError(msg)
 
     # Copy the circuit and separate all instructions by ticks
     circ_cpy = Circuit()
@@ -187,7 +187,7 @@ def collect_circuit_layers(
             circ.pop(gate_idx - n_deleted)
 
     if scheduling_method == "alap":
-        layers = layers[::-1]  # Reverse the layers back for ALAP scheduling
+        layers.reverse()  # Reverse the layers back for ALAP scheduling
 
     return layers
 
@@ -246,17 +246,11 @@ def compose_circuits(
     # map non-connected of circ1 to the first n_connected qubits
     non_connected_mapping1 = {q: i for i, q in enumerate(non_connected_circ1)}
     # map non-connected of circ 2 to the qubits n_connected...n_connected + len(circ2)-1
-    non_connected_mapping2 = {
-        q: i + len(non_connected_circ1) for i, q in enumerate(non_connected_circ2)
-    }
+    non_connected_mapping2 = {q: i + len(non_connected_circ1) for i, q in enumerate(non_connected_circ2)}
     # map connected qubits to the last n_connected qubits
-    connected_mapping1 = {
-        q: i + len(non_connected_circ1) + len(non_connected_circ2)
-        for i, q in enumerate(connected)
-    }
+    connected_mapping1 = {q: i + len(non_connected_circ1) + len(non_connected_circ2) for i, q in enumerate(connected)}
     connected_mapping2 = {
-        wiring[q]: i + len(non_connected_circ1) + len(non_connected_circ2)
-        for i, q in enumerate(connected)
+        wiring[q]: i + len(non_connected_circ1) + len(non_connected_circ2) for i, q in enumerate(connected)
     }
 
     mapping1 = {**non_connected_mapping1, **connected_mapping1}

--- a/src/mqt/qecc/circuit_synthesis/circuit_utils.py
+++ b/src/mqt/qecc/circuit_synthesis/circuit_utils.py
@@ -69,7 +69,7 @@ def qiskit_to_stim_circuit(qc: QuantumCircuit) -> Circuit:
     return stim_circuit
 
 
-def compact_stim_circuit(circ: Circuit) -> Circuit:
+def compact_stim_circuit(circ: Circuit, scheduling_method: str = "asap") -> Circuit:
     """Move circuit instructions to the front and ignore TICKS.
 
     Args:
@@ -78,20 +78,26 @@ def compact_stim_circuit(circ: Circuit) -> Circuit:
          A compacted stim circuit.
     """
     compact_circ = Circuit()
-    for layer in collect_circuit_layers(circ):
+    for layer in collect_circuit_layers(circ, scheduling_method):
         compact_circ += layer
     return compact_circ
 
 
-def collect_circuit_layers(circ: Circuit) -> list[Circuit]:
+def collect_circuit_layers(
+    circ: Circuit, scheduling_method: str = "asap"
+) -> list[Circuit]:
     """Collect all layers that can be executed in parallel.
 
     Args:
         circ: Stim circuit to process.
+        scheduling_method: Either "asap" (as soon as possible) or "alap" (as late as possible).
 
     Returns:
         list of circuit layers. All instructions in one layer can be executed in parallel. It holds that circ=sum(collect_circuit_layers(circ)).
     """
+    if scheduling_method not in ("asap", "alap"):
+        raise ValueError("scheduling_method must be 'asap' or 'alap'.")
+
     # Copy the circuit and separate all instructions by ticks
     circ_cpy = Circuit()
     for instr in circ:
@@ -99,6 +105,9 @@ def collect_circuit_layers(circ: Circuit) -> list[Circuit]:
             qubits = [q.qubit_value for q in grp]
             circ_cpy.append_operation(instr.name, qubits)
             circ_cpy.append_operation("TICK", [])
+
+    if scheduling_method == "alap":
+        circ_cpy = circ_cpy[::-1]  # Reverse the circuit for ALAP scheduling
 
     # Now work with the copied circuit
     circ = circ_cpy
@@ -141,6 +150,9 @@ def collect_circuit_layers(circ: Circuit) -> list[Circuit]:
         # Remove the instructions that were added to the layer
         for n_deleted, gate_idx in enumerate(instr_to_delete):
             circ.pop(gate_idx - n_deleted)
+
+    if scheduling_method == "alap":
+        layers = layers[::-1]  # Reverse the layers back for ALAP scheduling
 
     return layers
 
@@ -199,11 +211,17 @@ def compose_circuits(
     # map non-connected of circ1 to the first n_connected qubits
     non_connected_mapping1 = {q: i for i, q in enumerate(non_connected_circ1)}
     # map non-connected of circ 2 to the qubits n_connected...n_connected + len(circ2)-1
-    non_connected_mapping2 = {q: i + len(non_connected_circ1) for i, q in enumerate(non_connected_circ2)}
+    non_connected_mapping2 = {
+        q: i + len(non_connected_circ1) for i, q in enumerate(non_connected_circ2)
+    }
     # map connected qubits to the last n_connected qubits
-    connected_mapping1 = {q: i + len(non_connected_circ1) + len(non_connected_circ2) for i, q in enumerate(connected)}
+    connected_mapping1 = {
+        q: i + len(non_connected_circ1) + len(non_connected_circ2)
+        for i, q in enumerate(connected)
+    }
     connected_mapping2 = {
-        wiring[q]: i + len(non_connected_circ1) + len(non_connected_circ2) for i, q in enumerate(connected)
+        wiring[q]: i + len(non_connected_circ1) + len(non_connected_circ2)
+        for i, q in enumerate(connected)
     }
 
     mapping1 = {**non_connected_mapping1, **connected_mapping1}

--- a/src/mqt/qecc/circuit_synthesis/circuit_utils.py
+++ b/src/mqt/qecc/circuit_synthesis/circuit_utils.py
@@ -83,9 +83,7 @@ def compact_stim_circuit(circ: Circuit, scheduling_method: str = "asap") -> Circ
     return compact_circ
 
 
-def compose_compact_stim_circuits(
-    circs: list[Circuit], align: str = "start"
-) -> Circuit:
+def compose_compact_stim_circuits(circs: list[Circuit], align: str = "start") -> Circuit:
     """Compose and compact multiple stim circuits.
 
     Args:
@@ -95,8 +93,9 @@ def compose_compact_stim_circuits(
     Returns:
         A composed and compacted stim circuit.
     """
-    if align not in ("start", "end"):
-        raise ValueError("align must be 'start' or 'end'.")
+    if align not in {"start", "end"}:
+        msg = "align must be 'start' or 'end'."
+        raise ValueError(msg)
 
     composed_layers: list[Circuit] = []
     for circ in circs:
@@ -110,7 +109,7 @@ def compose_compact_stim_circuits(
                 composed_layers.append(layer_circ)
 
     if align == "end":
-        composed_layers = composed_layers[::-1]
+        composed_layers.reverse()
 
     compose_circ = Circuit()
     for layer in composed_layers:
@@ -118,9 +117,7 @@ def compose_compact_stim_circuits(
     return compose_circ
 
 
-def collect_circuit_layers(
-    circ: Circuit, scheduling_method: str = "asap"
-) -> list[Circuit]:
+def collect_circuit_layers(circ: Circuit, scheduling_method: str = "asap") -> list[Circuit]:
     """Collect all layers that can be executed in parallel.
 
     Args:
@@ -130,8 +127,9 @@ def collect_circuit_layers(
     Returns:
         list of circuit layers. All instructions in one layer can be executed in parallel. It holds that circ=sum(collect_circuit_layers(circ)).
     """
-    if scheduling_method not in ("asap", "alap"):
-        raise ValueError("scheduling_method must be 'asap' or 'alap'.")
+    if scheduling_method not in {"asap", "alap"}:
+        msg = "scheduling_method must be 'asap' or 'alap'."
+        raise ValueError(msg)
 
     # Copy the circuit and separate all instructions by ticks
     circ_cpy = Circuit()
@@ -187,7 +185,7 @@ def collect_circuit_layers(
             circ.pop(gate_idx - n_deleted)
 
     if scheduling_method == "alap":
-        layers = layers[::-1]  # Reverse the layers back for ALAP scheduling
+        layers.reverse()  # Reverse the layers back for ALAP scheduling
 
     return layers
 
@@ -246,17 +244,11 @@ def compose_circuits(
     # map non-connected of circ1 to the first n_connected qubits
     non_connected_mapping1 = {q: i for i, q in enumerate(non_connected_circ1)}
     # map non-connected of circ 2 to the qubits n_connected...n_connected + len(circ2)-1
-    non_connected_mapping2 = {
-        q: i + len(non_connected_circ1) for i, q in enumerate(non_connected_circ2)
-    }
+    non_connected_mapping2 = {q: i + len(non_connected_circ1) for i, q in enumerate(non_connected_circ2)}
     # map connected qubits to the last n_connected qubits
-    connected_mapping1 = {
-        q: i + len(non_connected_circ1) + len(non_connected_circ2)
-        for i, q in enumerate(connected)
-    }
+    connected_mapping1 = {q: i + len(non_connected_circ1) + len(non_connected_circ2) for i, q in enumerate(connected)}
     connected_mapping2 = {
-        wiring[q]: i + len(non_connected_circ1) + len(non_connected_circ2)
-        for i, q in enumerate(connected)
+        wiring[q]: i + len(non_connected_circ1) + len(non_connected_circ2) for i, q in enumerate(connected)
     }
 
     mapping1 = {**non_connected_mapping1, **connected_mapping1}

--- a/src/mqt/qecc/circuit_synthesis/circuit_utils.py
+++ b/src/mqt/qecc/circuit_synthesis/circuit_utils.py
@@ -83,6 +83,41 @@ def compact_stim_circuit(circ: Circuit, scheduling_method: str = "asap") -> Circ
     return compact_circ
 
 
+def compose_compact_stim_circuits(
+    circs: list[Circuit], align: str = "start"
+) -> Circuit:
+    """Compose and compact multiple stim circuits.
+
+    Args:
+        circs: List of stim circuits to compose and compact.
+        align: Either "start" (align at the start) or "end" (align at the end).
+
+    Returns:
+        A composed and compacted stim circuit.
+    """
+    if align not in ("start", "end"):
+        raise ValueError("align must be 'start' or 'end'.")
+
+    composed_layers: list[Circuit] = []
+    for circ in circs:
+        layers = collect_circuit_layers(circ, "asap" if align == "start" else "alap")
+        if align == "end":
+            layers = layers[::-1]
+        for i, layer_circ in enumerate(layers):
+            if i < len(composed_layers):
+                composed_layers[i] += layer_circ
+            else:
+                composed_layers.append(layer_circ)
+
+    if align == "end":
+        composed_layers = composed_layers[::-1]
+
+    compose_circ = Circuit()
+    for layer in composed_layers:
+        compose_circ += layer
+    return compose_circ
+
+
 def collect_circuit_layers(
     circ: Circuit, scheduling_method: str = "asap"
 ) -> list[Circuit]:

--- a/tests/circuit_synthesis/test_utils.py
+++ b/tests/circuit_synthesis/test_utils.py
@@ -22,8 +22,8 @@ from stim import Flow, PauliString
 from mqt.qecc.circuit_synthesis.circuit_utils import (
     collect_circuit_layers,
     compact_stim_circuit,
-    compose_compact_stim_circuits,
     compose_circuits,
+    compose_compact_stim_circuits,
     measured_qubits,
     qiskit_to_stim_circuit,
     unmeasured_qubits,
@@ -90,9 +90,7 @@ def identity_matrix() -> MatrixTest:
 def full_matrix() -> MatrixTest:
     """Return a 4x4 matrix with all ones."""
     return MatrixTest(
-        np.array(
-            [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], dtype=np.int8
-        ),
+        np.array([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], dtype=np.int8),
         3,
         2,
     )
@@ -211,16 +209,11 @@ def correct_stabilizer_propagation(
     circ = qiskit_to_stim_circuit(qc)
     pauli = "Z" if z_measurement else "X"
     anc_idx = qc.find_bit(ancilla).index
-    initial_pauli = PauliString(
-        "_" * (anc_idx) + "Z" + "_" * (len(qc.qubits) - anc_idx - 1)
-    )
+    initial_pauli = PauliString("_" * (anc_idx) + "Z" + "_" * (len(qc.qubits) - anc_idx - 1))
     final_pauli = PauliString(
-        "".join([pauli if q in stab else "_" for q in qc.qubits])
-        + "_" * (len(qc.qubits) - anc_idx - 1)
+        "".join([pauli if q in stab else "_" for q in qc.qubits]) + "_" * (len(qc.qubits) - anc_idx - 1)
     )
-    f = Flow(
-        input=initial_pauli, output=final_pauli, measurements=[qc.num_ancillas - 1]
-    )
+    f = Flow(input=initial_pauli, output=final_pauli, measurements=[qc.num_ancillas - 1])
     return bool(circ.has_flow(f))
 
 
@@ -234,15 +227,9 @@ def test_one_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=1, z_measurement=z_measurement
-    )
-    assert qc.depth() == len(stab) + 3 + 2 * int(
-        not z_measurement
-    )  # 6 CNOTs + Measurement + 2 possible hadamards
-    assert (
-        qc.count_ops().get("cx", 0) == len(stab) + 2
-    )  # CNOTs from measurement + 2 flagging CNOTs
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=1, z_measurement=z_measurement)
+    assert qc.depth() == len(stab) + 3 + 2 * int(not z_measurement)  # 6 CNOTs + Measurement + 2 possible hadamards
+    assert qc.count_ops().get("cx", 0) == len(stab) + 2  # CNOTs from measurement + 2 flagging CNOTs
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -256,9 +243,7 @@ def test_two_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=2, z_measurement=z_measurement
-    )
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=2, z_measurement=z_measurement)
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -272,9 +257,7 @@ def test_three_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=3, z_measurement=z_measurement
-    )
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=3, z_measurement=z_measurement)
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -302,9 +285,7 @@ def test_w_flag(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=w, z_measurement=z_measurement
-    )
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=w, z_measurement=z_measurement)
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -368,9 +349,7 @@ class TestSymbolicVectorOperations:
         """Test symbolic_vector_eq with vectors of different lengths."""
         lhs = np.array([True, False, self.x])
         rhs = np.array([True, False])
-        with pytest.raises(
-            ValueError, match=r"Vectors must have the same length for equality check."
-        ):
+        with pytest.raises(ValueError, match=r"Vectors must have the same length for equality check."):
             symbolic_vector_eq(lhs, rhs)
 
     @pytest.mark.parametrize(
@@ -405,9 +384,7 @@ class TestSymbolicVectorOperations:
         """Parameterized test for ~odd_overlap~."""
         solver = z3.Solver()
         solver.add(odd_overlap(v_sym, v_con))
-        assert solver.check() == expected_result, (
-            f"Test failed for v_sym={v_sym}, v_con={v_con}"
-        )
+        assert solver.check() == expected_result, f"Test failed for v_sym={v_sym}, v_con={v_con}"
 
     @pytest.mark.parametrize(
         ("v", "scalar", "expected_result"),
@@ -431,9 +408,7 @@ class TestSymbolicVectorOperations:
     def test_symbolic_scalar_mult(self, v, scalar, expected_result):  # noqa: PLR6301
         """Parameterized test for ~symbolic_scalar_mult~."""
         result = symbolic_scalar_mult(v, scalar)
-        assert np.array_equal(result, expected_result), (
-            f"Test failed for v={v}, scalar={scalar}"
-        )
+        assert np.array_equal(result, expected_result), f"Test failed for v={v}, scalar={scalar}"
 
     @pytest.mark.parametrize(
         ("v1", "v2", "expected_result"),
@@ -469,9 +444,7 @@ class TestSymbolicVectorOperations:
     def test_symbolic_vector_add(self, v1, v2, expected_result):  # noqa: PLR6301
         """Parameterized test for ~symbolic_vector_add~."""
         result = symbolic_vector_add(v1, v2)
-        assert np.array_equal(result, expected_result), (
-            f"Test failed for v1={v1}, v2={v2}"
-        )
+        assert np.array_equal(result, expected_result), f"Test failed for v1={v1}, v2={v2}"
 
     @pytest.mark.parametrize(
         ("measurement", "generators", "expected_result"),
@@ -528,9 +501,7 @@ class TestSymbolicVectorOperations:
             ),
         ],
     )
-    def test_vars_to_stab_exceptions(
-        self, measurement, generators, expected_exception, expected_message
-    ):  # noqa: PLR6301
+    def test_vars_to_stab_exceptions(self, measurement, generators, expected_exception, expected_message):
         """Test ~vars_to_stab~ with invalid inputs that raise exceptions."""
         with pytest.raises(expected_exception, match=expected_message):
             vars_to_stab(measurement, generators)
@@ -557,9 +528,7 @@ def test_collect_circuit_layers_asap() -> None:
     # Two layers: RX+H first (parallel), then CX
     assert len(layers) == 2
     # RX 0 and H 2 can be in either order in the same layer
-    assert layers[0] == stim.Circuit("RX 0\nH 2") or layers[0] == stim.Circuit(
-        "H 2\nRX 0"
-    )
+    assert layers[0] == stim.Circuit("RX 0\nH 2") or layers[0] == stim.Circuit("H 2\nRX 0")
     assert layers[1] == stim.Circuit("CX 0 1")
 
 
@@ -576,9 +545,7 @@ def test_collect_circuit_layers_alap() -> None:
     # Two layers: CX first, then RX+H
     assert len(layers) == 2
     assert layers[0] == stim.Circuit("RX 0")
-    assert layers[1] == stim.Circuit("CX 0 1\nH 2") or layers[1] == stim.Circuit(
-        "H 2\nCX 0 1"
-    )
+    assert layers[1] == stim.Circuit("CX 0 1\nH 2") or layers[1] == stim.Circuit("H 2\nCX 0 1")
 
 
 def test_invalid_scheduling_method() -> None:

--- a/tests/circuit_synthesis/test_utils.py
+++ b/tests/circuit_synthesis/test_utils.py
@@ -22,6 +22,7 @@ from stim import Flow, PauliString
 from mqt.qecc.circuit_synthesis.circuit_utils import (
     collect_circuit_layers,
     compact_stim_circuit,
+    compose_compact_stim_circuits,
     compose_circuits,
     measured_qubits,
     qiskit_to_stim_circuit,
@@ -320,6 +321,22 @@ def test_compact_stim_circuit() -> None:
     assert len(compacted) == 2
     compacted = compact_stim_circuit(circ, scheduling_method="alap")
     assert len(compacted) == 2
+
+
+def test_compose_compact_stim_circuits() -> None:
+    """Test compaction method."""
+    circ1 = stim.Circuit()
+    circ1.append("H", [0])
+    circ1.append("CX", [0, 1])
+    circ2 = stim.Circuit()
+    circ2.append("CX", [2, 3])
+
+    compacted1 = compose_compact_stim_circuits([circ1, circ2], align="start")
+    assert len(compacted1) == 2
+    assert compacted1 == stim.Circuit("H 0\nCX 2 3 0 1")
+    compacted2 = compose_compact_stim_circuits([circ1, circ2], align="end")
+    assert len(compacted2) == 2
+    assert compacted2 == stim.Circuit("H 0\nCX 0 1 2 3")
 
 
 class TestSymbolicVectorOperations:

--- a/tests/circuit_synthesis/test_utils.py
+++ b/tests/circuit_synthesis/test_utils.py
@@ -55,7 +55,9 @@ class MatrixTest(NamedTuple):
 
 
 def check_correct_elimination(
-    matrix: npt.NDArray[np.int8], final_matrix: npt.NDArray[np.int8], col_ops: list[tuple[int, int]]
+    matrix: npt.NDArray[np.int8],
+    final_matrix: npt.NDArray[np.int8],
+    col_ops: list[tuple[int, int]],
 ) -> bool:
     """Check if the matrix is correctly eliminated."""
     matrix = matrix.copy()
@@ -86,7 +88,13 @@ def identity_matrix() -> MatrixTest:
 @pytest.fixture
 def full_matrix() -> MatrixTest:
     """Return a 4x4 matrix with all ones."""
-    return MatrixTest(np.array([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], dtype=np.int8), 3, 2)
+    return MatrixTest(
+        np.array(
+            [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], dtype=np.int8
+        ),
+        3,
+        2,
+    )
 
 
 @pytest.fixture
@@ -121,7 +129,10 @@ def _make_measurement_test(n: int, stab: list[int]) -> MeasurementTest:
     return MeasurementTest(qc, stab_qubits, ancilla, measurement_bit)
 
 
-@pytest.mark.parametrize("test_vals", ["identity_matrix", "full_matrix", "single_row_matrix", "single_column_matrix"])
+@pytest.mark.parametrize(
+    "test_vals",
+    ["identity_matrix", "full_matrix", "single_row_matrix", "single_column_matrix"],
+)
 def test_min_column_ops(test_vals: MatrixTest, request) -> None:  # type: ignore[no-untyped-def]
     """Check correct number of column operations are returned."""
     fixture = request.getfixturevalue(test_vals)
@@ -129,7 +140,9 @@ def test_min_column_ops(test_vals: MatrixTest, request) -> None:  # type: ignore
     min_col_ops = fixture.min_col_ops
     rank = mod2.rank(matrix)
     res = gaussian_elimination_min_column_ops(
-        matrix, lambda checks: final_matrix_constraint(checks, rank), max_eliminations=fixture.min_col_ops
+        matrix,
+        lambda checks: final_matrix_constraint(checks, rank),
+        max_eliminations=fixture.min_col_ops,
     )
     assert res is not None
     reduced, ops = res
@@ -137,7 +150,10 @@ def test_min_column_ops(test_vals: MatrixTest, request) -> None:  # type: ignore
     assert check_correct_elimination(matrix, reduced, ops)
 
 
-@pytest.mark.parametrize("test_vals", ["identity_matrix", "full_matrix", "single_row_matrix", "single_column_matrix"])
+@pytest.mark.parametrize(
+    "test_vals",
+    ["identity_matrix", "full_matrix", "single_row_matrix", "single_column_matrix"],
+)
 def test_min_parallel_eliminations(test_vals: MatrixTest, request) -> None:  # type: ignore[no-untyped-def]
     """Check correct number of parallel eliminations are returned."""
     fixture = request.getfixturevalue(test_vals)
@@ -145,7 +161,9 @@ def test_min_parallel_eliminations(test_vals: MatrixTest, request) -> None:  # t
     rank = mod2.rank(matrix)
     max_parallel_steps = fixture.max_parallel_steps
     res = gaussian_elimination_min_parallel_eliminations(
-        matrix, lambda checks: final_matrix_constraint(checks, rank), max_parallel_steps=fixture.max_parallel_steps
+        matrix,
+        lambda checks: final_matrix_constraint(checks, rank),
+        max_parallel_steps=fixture.max_parallel_steps,
     )
     assert res is not None
     reduced, ops = res
@@ -156,7 +174,10 @@ def test_min_parallel_eliminations(test_vals: MatrixTest, request) -> None:  # t
     assert n_parallel_layers <= max_parallel_steps
 
 
-@pytest.mark.parametrize("test_vals", ["identity_matrix", "full_matrix", "single_row_matrix", "single_column_matrix"])
+@pytest.mark.parametrize(
+    "test_vals",
+    ["identity_matrix", "full_matrix", "single_row_matrix", "single_column_matrix"],
+)
 def test_heuristic_gaussian_elimination(test_vals: MatrixTest, request) -> None:  # type: ignore[no-untyped-def]
     """Test heuristic Gaussian elimination method."""
     fixture = request.getfixturevalue(test_vals)
@@ -189,11 +210,16 @@ def correct_stabilizer_propagation(
     circ = qiskit_to_stim_circuit(qc)
     pauli = "Z" if z_measurement else "X"
     anc_idx = qc.find_bit(ancilla).index
-    initial_pauli = PauliString("_" * (anc_idx) + "Z" + "_" * (len(qc.qubits) - anc_idx - 1))
-    final_pauli = PauliString(
-        "".join([pauli if q in stab else "_" for q in qc.qubits]) + "_" * (len(qc.qubits) - anc_idx - 1)
+    initial_pauli = PauliString(
+        "_" * (anc_idx) + "Z" + "_" * (len(qc.qubits) - anc_idx - 1)
     )
-    f = Flow(input=initial_pauli, output=final_pauli, measurements=[qc.num_ancillas - 1])
+    final_pauli = PauliString(
+        "".join([pauli if q in stab else "_" for q in qc.qubits])
+        + "_" * (len(qc.qubits) - anc_idx - 1)
+    )
+    f = Flow(
+        input=initial_pauli, output=final_pauli, measurements=[qc.num_ancillas - 1]
+    )
     return bool(circ.has_flow(f))
 
 
@@ -207,9 +233,15 @@ def test_one_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(qc, stab, ancilla, measurement_bit, t=1, z_measurement=z_measurement)
-    assert qc.depth() == len(stab) + 3 + 2 * int(not z_measurement)  # 6 CNOTs + Measurement + 2 possible hadamards
-    assert qc.count_ops().get("cx", 0) == len(stab) + 2  # CNOTs from measurement + 2 flagging CNOTs
+    measure_flagged(
+        qc, stab, ancilla, measurement_bit, t=1, z_measurement=z_measurement
+    )
+    assert qc.depth() == len(stab) + 3 + 2 * int(
+        not z_measurement
+    )  # 6 CNOTs + Measurement + 2 possible hadamards
+    assert (
+        qc.count_ops().get("cx", 0) == len(stab) + 2
+    )  # CNOTs from measurement + 2 flagging CNOTs
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -223,7 +255,9 @@ def test_two_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(qc, stab, ancilla, measurement_bit, t=2, z_measurement=z_measurement)
+    measure_flagged(
+        qc, stab, ancilla, measurement_bit, t=2, z_measurement=z_measurement
+    )
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -237,7 +271,9 @@ def test_three_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(qc, stab, ancilla, measurement_bit, t=3, z_measurement=z_measurement)
+    measure_flagged(
+        qc, stab, ancilla, measurement_bit, t=3, z_measurement=z_measurement
+    )
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -265,7 +301,9 @@ def test_w_flag(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(qc, stab, ancilla, measurement_bit, t=w, z_measurement=z_measurement)
+    measure_flagged(
+        qc, stab, ancilla, measurement_bit, t=w, z_measurement=z_measurement
+    )
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -278,7 +316,9 @@ def test_compact_stim_circuit() -> None:
     circ.append("CX", [2, 3])
 
     assert len(circ) == 4
-    compacted = compact_stim_circuit(circ)
+    compacted = compact_stim_circuit(circ, scheduling_method="asap")
+    assert len(compacted) == 2
+    compacted = compact_stim_circuit(circ, scheduling_method="alap")
     assert len(compacted) == 2
 
 
@@ -311,16 +351,30 @@ class TestSymbolicVectorOperations:
         """Test symbolic_vector_eq with vectors of different lengths."""
         lhs = np.array([True, False, self.x])
         rhs = np.array([True, False])
-        with pytest.raises(ValueError, match=r"Vectors must have the same length for equality check."):
+        with pytest.raises(
+            ValueError, match=r"Vectors must have the same length for equality check."
+        ):
             symbolic_vector_eq(lhs, rhs)
 
     @pytest.mark.parametrize(
         ("v_sym", "v_con", "expected_result"),
         [
             # Empty constant vector
-            (np.array([z3.Bool(f"x{i}") for i in range(5)]), np.array([0, 0, 0, 0, 0], dtype=np.int8), z3.unsat),
-            (np.array([z3.Bool(f"x{i}") for i in range(5)]), np.array([1, 0, 1, 0, 0], dtype=np.int8), z3.sat),
-            (np.array([z3.Bool(f"x{i}") for i in range(5)]), np.array([1, 0, 1, 0, 1], dtype=np.int8), z3.sat),
+            (
+                np.array([z3.Bool(f"x{i}") for i in range(5)]),
+                np.array([0, 0, 0, 0, 0], dtype=np.int8),
+                z3.unsat,
+            ),
+            (
+                np.array([z3.Bool(f"x{i}") for i in range(5)]),
+                np.array([1, 0, 1, 0, 0], dtype=np.int8),
+                z3.sat,
+            ),
+            (
+                np.array([z3.Bool(f"x{i}") for i in range(5)]),
+                np.array([1, 0, 1, 0, 1], dtype=np.int8),
+                z3.sat,
+            ),
             # Mixed boolean and symbolic values
             (
                 np.array([True, z3.Bool("x1"), False, z3.Bool("x3"), True]),
@@ -334,7 +388,9 @@ class TestSymbolicVectorOperations:
         """Parameterized test for ~odd_overlap~."""
         solver = z3.Solver()
         solver.add(odd_overlap(v_sym, v_con))
-        assert solver.check() == expected_result, f"Test failed for v_sym={v_sym}, v_con={v_con}"
+        assert solver.check() == expected_result, (
+            f"Test failed for v_sym={v_sym}, v_con={v_con}"
+        )
 
     @pytest.mark.parametrize(
         ("v", "scalar", "expected_result"),
@@ -344,7 +400,11 @@ class TestSymbolicVectorOperations:
             # Scalar multiplication with True
             (np.array([1, 0, 1], dtype=np.int8), True, np.array([True, False, True])),
             # Scalar multiplication with False
-            (np.array([1, 0, 1], dtype=np.int8), False, np.array([False, False, False])),
+            (
+                np.array([1, 0, 1], dtype=np.int8),
+                False,
+                np.array([False, False, False]),
+            ),
             # Scalar multiplication with a Z3 variable (x)
             (np.array([1, 0, 1], dtype=np.int8), x, np.array([x, False, x])),
             # Scalar multiplication with a Z3 variable (y)
@@ -354,7 +414,9 @@ class TestSymbolicVectorOperations:
     def test_symbolic_scalar_mult(self, v, scalar, expected_result):  # noqa: PLR6301
         """Parameterized test for ~symbolic_scalar_mult~."""
         result = symbolic_scalar_mult(v, scalar)
-        assert np.array_equal(result, expected_result), f"Test failed for v={v}, scalar={scalar}"
+        assert np.array_equal(result, expected_result), (
+            f"Test failed for v={v}, scalar={scalar}"
+        )
 
     @pytest.mark.parametrize(
         ("v1", "v2", "expected_result"),
@@ -362,7 +424,11 @@ class TestSymbolicVectorOperations:
             # Empty vectors
             (np.array([]), np.array([]), np.array([])),
             # Addition of boolean vectors
-            (np.array([True, False, True]), np.array([False, True, False]), np.array([True, True, True])),
+            (
+                np.array([True, False, True]),
+                np.array([False, True, False]),
+                np.array([True, True, True]),
+            ),
             # Addition of symbolic vectors
             (
                 np.array([x, y, z3.Not(x)]),
@@ -370,27 +436,53 @@ class TestSymbolicVectorOperations:
                 np.array([z3.BoolVal(False), z3.BoolVal(False), z3.BoolVal(False)]),
             ),
             # Mixed boolean and symbolic vectors
-            (np.array([True, False, x]), np.array([False, True, y]), np.array([True, True, z3.Xor(x, y)])),
+            (
+                np.array([True, False, x]),
+                np.array([False, True, y]),
+                np.array([True, True, z3.Xor(x, y)]),
+            ),
             # Boolean and symbolic simplifications
-            (np.array([True, x, False]), np.array([False, y, True]), np.array([True, z3.Xor(x, y), True])),
+            (
+                np.array([True, x, False]),
+                np.array([False, y, True]),
+                np.array([True, z3.Xor(x, y), True]),
+            ),
         ],
     )
     def test_symbolic_vector_add(self, v1, v2, expected_result):  # noqa: PLR6301
         """Parameterized test for ~symbolic_vector_add~."""
         result = symbolic_vector_add(v1, v2)
-        assert np.array_equal(result, expected_result), f"Test failed for v1={v1}, v2={v2}"
+        assert np.array_equal(result, expected_result), (
+            f"Test failed for v1={v1}, v2={v2}"
+        )
 
     @pytest.mark.parametrize(
         ("measurement", "generators", "expected_result"),
         [
             # Single generator
-            ([True], np.array([[1, 0, 1]], dtype=np.int8), np.array([True, False, True])),
+            (
+                [True],
+                np.array([[1, 0, 1]], dtype=np.int8),
+                np.array([True, False, True]),
+            ),
             # Multiple generators with boolean measurements
-            ([True, False], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8), np.array([True, False, True])),
+            (
+                [True, False],
+                np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8),
+                np.array([True, False, True]),
+            ),
             # Multiple generators with symbolic measurements
-            ([x, y], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8), np.array([x, y, x])),
+            (
+                [x, y],
+                np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8),
+                np.array([x, y, x]),
+            ),
             # Mixed boolean and symbolic measurements
-            ([True, y], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8), np.array([True, y, True])),
+            (
+                [True, y],
+                np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8),
+                np.array([True, y, True]),
+            ),
         ],
     )
     def test_vars_to_stab_valid_inputs(self, measurement, generators, expected_result):  # noqa: PLR6301
@@ -404,7 +496,12 @@ class TestSymbolicVectorOperations:
         ("measurement", "generators", "expected_exception", "expected_message"),
         [
             # Empty measurement
-            ([], np.array([[1, 0, 1]], dtype=np.int8), ValueError, "Measurement must not be empty"),
+            (
+                [],
+                np.array([[1, 0, 1]], dtype=np.int8),
+                ValueError,
+                "Measurement must not be empty",
+            ),
             # Mismatched lengths
             (
                 [True],
@@ -414,7 +511,9 @@ class TestSymbolicVectorOperations:
             ),
         ],
     )
-    def test_vars_to_stab_exceptions(self, measurement, generators, expected_exception, expected_message):  # noqa: PLR6301
+    def test_vars_to_stab_exceptions(
+        self, measurement, generators, expected_exception, expected_message
+    ):  # noqa: PLR6301
         """Test ~vars_to_stab~ with invalid inputs that raise exceptions."""
         with pytest.raises(expected_exception, match=expected_message):
             vars_to_stab(measurement, generators)
@@ -428,18 +527,48 @@ def test_compact_stim_circuit_empty() -> None:
     assert len(compacted) == 0
 
 
-def test_collect_circuit_layers() -> None:
-    """Test collecting circuit layers."""
+def test_collect_circuit_layers_asap() -> None:
+    """Test collecting circuit layers with ASAP scheduling."""
     circ = stim.Circuit()
     circ.append("RX", [0])
     circ.append("CX", [0, 1])
     circ.append("TICK")
     circ.append("H", [2])
 
-    layers = collect_circuit_layers(circ)
-    assert len(layers) == 2  # Two layers of operations
-    assert layers[0] == stim.Circuit("RX 0\nH 2") or layers[0] == stim.Circuit("H 2\nRX 0")
+    layers = collect_circuit_layers(circ, scheduling_method="asap")
+
+    # Two layers: RX+H first (parallel), then CX
+    assert len(layers) == 2
+    # RX 0 and H 2 can be in either order in the same layer
+    assert layers[0] == stim.Circuit("RX 0\nH 2") or layers[0] == stim.Circuit(
+        "H 2\nRX 0"
+    )
     assert layers[1] == stim.Circuit("CX 0 1")
+
+
+def test_collect_circuit_layers_alap() -> None:
+    """Test collecting circuit layers with ALAP scheduling."""
+    circ = stim.Circuit()
+    circ.append("RX", [0])
+    circ.append("CX", [0, 1])
+    circ.append("TICK")
+    circ.append("H", [2])
+
+    layers = collect_circuit_layers(circ, scheduling_method="alap")
+
+    # Two layers: CX first, then RX+H
+    assert len(layers) == 2
+    assert layers[0] == stim.Circuit("RX 0")
+    assert layers[1] == stim.Circuit("CX 0 1\nH 2") or layers[1] == stim.Circuit(
+        "H 2\nCX 0 1"
+    )
+
+
+def test_invalid_scheduling_method() -> None:
+    """Test invalid scheduling method raises an error."""
+    circ = stim.Circuit("H 0")
+    with pytest.raises(ValueError, match="scheduling_method must be 'asap' or 'alap'"):
+        collect_circuit_layers(circ, scheduling_method="foo")
 
 
 def test_collect_circuit_layers_empty_circuit() -> None:
@@ -510,7 +639,14 @@ def test_measured_qubits(circuit_operations, expected_measured):
 
 
 @pytest.mark.parametrize(
-    ("circ1_ops", "circ2_ops", "wiring", "expected_num_qubits", "expected_mapping1", "expected_mapping2"),
+    (
+        "circ1_ops",
+        "circ2_ops",
+        "wiring",
+        "expected_num_qubits",
+        "expected_mapping1",
+        "expected_mapping2",
+    ),
     [
         # Test case 1: No wiring, circuits are vertically stacked
         (
@@ -550,7 +686,14 @@ def test_measured_qubits(circuit_operations, expected_measured):
         ),
     ],
 )
-def test_compose_circuits(circ1_ops, circ2_ops, wiring, expected_num_qubits, expected_mapping1, expected_mapping2):
+def test_compose_circuits(
+    circ1_ops,
+    circ2_ops,
+    wiring,
+    expected_num_qubits,
+    expected_mapping1,
+    expected_mapping2,
+):
     """Parameterized test for compose_circuits."""
     # Create the first circuit
     circ1 = stim.Circuit()

--- a/tests/circuit_synthesis/test_utils.py
+++ b/tests/circuit_synthesis/test_utils.py
@@ -22,8 +22,8 @@ from stim import Flow, PauliString
 from mqt.qecc.circuit_synthesis.circuit_utils import (
     collect_circuit_layers,
     compact_stim_circuit,
-    compose_compact_stim_circuits,
     compose_circuits,
+    compose_compact_stim_circuits,
     measured_qubits,
     qiskit_to_stim_circuit,
     unmeasured_qubits,
@@ -90,9 +90,7 @@ def identity_matrix() -> MatrixTest:
 def full_matrix() -> MatrixTest:
     """Return a 4x4 matrix with all ones."""
     return MatrixTest(
-        np.array(
-            [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], dtype=np.int8
-        ),
+        np.array([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], dtype=np.int8),
         3,
         2,
     )
@@ -211,16 +209,11 @@ def correct_stabilizer_propagation(
     circ = qiskit_to_stim_circuit(qc)
     pauli = "Z" if z_measurement else "X"
     anc_idx = qc.find_bit(ancilla).index
-    initial_pauli = PauliString(
-        "_" * (anc_idx) + "Z" + "_" * (len(qc.qubits) - anc_idx - 1)
-    )
+    initial_pauli = PauliString("_" * (anc_idx) + "Z" + "_" * (len(qc.qubits) - anc_idx - 1))
     final_pauli = PauliString(
-        "".join([pauli if q in stab else "_" for q in qc.qubits])
-        + "_" * (len(qc.qubits) - anc_idx - 1)
+        "".join([pauli if q in stab else "_" for q in qc.qubits]) + "_" * (len(qc.qubits) - anc_idx - 1)
     )
-    f = Flow(
-        input=initial_pauli, output=final_pauli, measurements=[qc.num_ancillas - 1]
-    )
+    f = Flow(input=initial_pauli, output=final_pauli, measurements=[qc.num_ancillas - 1])
     return bool(circ.has_flow(f))
 
 
@@ -234,15 +227,9 @@ def test_one_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=1, z_measurement=z_measurement
-    )
-    assert qc.depth() == len(stab) + 3 + 2 * int(
-        not z_measurement
-    )  # 6 CNOTs + Measurement + 2 possible hadamards
-    assert (
-        qc.count_ops().get("cx", 0) == len(stab) + 2
-    )  # CNOTs from measurement + 2 flagging CNOTs
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=1, z_measurement=z_measurement)
+    assert qc.depth() == len(stab) + 3 + 2 * int(not z_measurement)  # 6 CNOTs + Measurement + 2 possible hadamards
+    assert qc.count_ops().get("cx", 0) == len(stab) + 2  # CNOTs from measurement + 2 flagging CNOTs
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -256,9 +243,7 @@ def test_two_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=2, z_measurement=z_measurement
-    )
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=2, z_measurement=z_measurement)
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -272,9 +257,7 @@ def test_three_flag_measurements(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=3, z_measurement=z_measurement
-    )
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=3, z_measurement=z_measurement)
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -302,9 +285,7 @@ def test_w_flag(w: int, z_measurement: bool) -> None:
     ancilla = z_test.ancilla
     measurement_bit = z_test.measurement_bit
 
-    measure_flagged(
-        qc, stab, ancilla, measurement_bit, t=w, z_measurement=z_measurement
-    )
+    measure_flagged(qc, stab, ancilla, measurement_bit, t=w, z_measurement=z_measurement)
     assert correct_stabilizer_propagation(qc, stab, ancilla, z_measurement)
 
 
@@ -339,6 +320,13 @@ def test_compose_compact_stim_circuits() -> None:
     assert compacted2 == stim.Circuit("H 0\nCX 0 1 2 3")
 
 
+def test_invalid_compose_option() -> None:
+    """Test invalid compaction option raises an error."""
+    circ1 = stim.Circuit(" ")
+    with pytest.raises(ValueError, match="align must be 'start' or 'end'"):
+        compose_compact_stim_circuits([circ1], align="foo")
+
+
 class TestSymbolicVectorOperations:
     """Test class for symbolic vector operations, including ~odd_overlap~."""
 
@@ -368,9 +356,7 @@ class TestSymbolicVectorOperations:
         """Test symbolic_vector_eq with vectors of different lengths."""
         lhs = np.array([True, False, self.x])
         rhs = np.array([True, False])
-        with pytest.raises(
-            ValueError, match=r"Vectors must have the same length for equality check."
-        ):
+        with pytest.raises(ValueError, match=r"Vectors must have the same length for equality check."):
             symbolic_vector_eq(lhs, rhs)
 
     @pytest.mark.parametrize(
@@ -405,9 +391,7 @@ class TestSymbolicVectorOperations:
         """Parameterized test for ~odd_overlap~."""
         solver = z3.Solver()
         solver.add(odd_overlap(v_sym, v_con))
-        assert solver.check() == expected_result, (
-            f"Test failed for v_sym={v_sym}, v_con={v_con}"
-        )
+        assert solver.check() == expected_result, f"Test failed for v_sym={v_sym}, v_con={v_con}"
 
     @pytest.mark.parametrize(
         ("v", "scalar", "expected_result"),
@@ -431,9 +415,7 @@ class TestSymbolicVectorOperations:
     def test_symbolic_scalar_mult(self, v, scalar, expected_result):  # noqa: PLR6301
         """Parameterized test for ~symbolic_scalar_mult~."""
         result = symbolic_scalar_mult(v, scalar)
-        assert np.array_equal(result, expected_result), (
-            f"Test failed for v={v}, scalar={scalar}"
-        )
+        assert np.array_equal(result, expected_result), f"Test failed for v={v}, scalar={scalar}"
 
     @pytest.mark.parametrize(
         ("v1", "v2", "expected_result"),
@@ -469,9 +451,7 @@ class TestSymbolicVectorOperations:
     def test_symbolic_vector_add(self, v1, v2, expected_result):  # noqa: PLR6301
         """Parameterized test for ~symbolic_vector_add~."""
         result = symbolic_vector_add(v1, v2)
-        assert np.array_equal(result, expected_result), (
-            f"Test failed for v1={v1}, v2={v2}"
-        )
+        assert np.array_equal(result, expected_result), f"Test failed for v1={v1}, v2={v2}"
 
     @pytest.mark.parametrize(
         ("measurement", "generators", "expected_result"),
@@ -528,9 +508,7 @@ class TestSymbolicVectorOperations:
             ),
         ],
     )
-    def test_vars_to_stab_exceptions(
-        self, measurement, generators, expected_exception, expected_message
-    ):  # noqa: PLR6301
+    def test_vars_to_stab_exceptions(self, measurement, generators, expected_exception, expected_message) -> None:
         """Test ~vars_to_stab~ with invalid inputs that raise exceptions."""
         with pytest.raises(expected_exception, match=expected_message):
             vars_to_stab(measurement, generators)
@@ -557,9 +535,7 @@ def test_collect_circuit_layers_asap() -> None:
     # Two layers: RX+H first (parallel), then CX
     assert len(layers) == 2
     # RX 0 and H 2 can be in either order in the same layer
-    assert layers[0] == stim.Circuit("RX 0\nH 2") or layers[0] == stim.Circuit(
-        "H 2\nRX 0"
-    )
+    assert layers[0] == stim.Circuit("RX 0\nH 2") or layers[0] == stim.Circuit("H 2\nRX 0")
     assert layers[1] == stim.Circuit("CX 0 1")
 
 
@@ -576,9 +552,7 @@ def test_collect_circuit_layers_alap() -> None:
     # Two layers: CX first, then RX+H
     assert len(layers) == 2
     assert layers[0] == stim.Circuit("RX 0")
-    assert layers[1] == stim.Circuit("CX 0 1\nH 2") or layers[1] == stim.Circuit(
-        "H 2\nCX 0 1"
-    )
+    assert layers[1] == stim.Circuit("CX 0 1\nH 2") or layers[1] == stim.Circuit("H 2\nCX 0 1")
 
 
 def test_invalid_scheduling_method() -> None:

--- a/tests/circuit_synthesis/test_utils.py
+++ b/tests/circuit_synthesis/test_utils.py
@@ -508,7 +508,7 @@ class TestSymbolicVectorOperations:
             ),
         ],
     )
-    def test_vars_to_stab_exceptions(self, measurement, generators, expected_exception, expected_message):
+    def test_vars_to_stab_exceptions(self, measurement, generators, expected_exception, expected_message):  # noqa: PLR6301
         """Test ~vars_to_stab~ with invalid inputs that raise exceptions."""
         with pytest.raises(expected_exception, match=expected_message):
             vars_to_stab(measurement, generators)


### PR DESCRIPTION
## Description

This PR adds the `compose_compact_stim_circuits` function to compose multiple circuits and align them either based on the circuit start or end using `compact_stim_circuit`.
It also adds a parameter to `compact_stim_circuit` to allow as-soon-as-possible and as-late-as-possible scheduling.

Thought this might be useful (at least for me it is).

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
