### PR TITLE
Replace unreachable early return with assert in _check_code_correct

### DIFF
--- a/src/mqt/qecc/codes/stabilizer_code.py
+++ b/src/mqt/qecc/codes/stabilizer_code.py
@@ -124,8 +124,7 @@ class StabilizerCode:
         if self.z_logicals is None:
             return
 
-        if self.x_logicals is None:
-            return
+        assert self.x_logicals is not None
 
         if self.z_logicals.n != self.n:
             msg = "Logical operators must have the same number of qubits as the stabilizer generators."


### PR DESCRIPTION
Motivation: The second early return in _check_code_correct is unreachable — the block above already raises InvalidStabilizerCodeError if exactly one logical is None, so by the time execution reaches the second check, both are guaranteed to be None or neither is. Replacing it with an assert makes this explicit and allows mypy to narrow the type correctly for the rest of the method.
Testing: No behavior change. Existing tests cover this.
Documentation: No documentation updates needed.