### PR TITLE
Custom input states for heuristic State Preparation Circuit

### DIFF
--- a/docs/StatePrep.md
+++ b/docs/StatePrep.md
@@ -14,7 +14,7 @@ mystnb:
 # Fault tolerant state preparation of Pauli eigenstates for CSS codes
 
 The QECC package contains functionality for synthesizing and simulating fault tolerant and non-fault tolerant state preparation circuits for Pauli eigenstates of CSS codes.
-Currently it supports synthesizing circuits for preparing the $|0\rangle_L^k$ and $|+\rangle_L^k$ states of arbitrary $[[n,k,d]]$ CSS codes.
+Currently it supports synthesizing circuits for preparing the any logical state of the form $\{|s\rangle_L \mid s \in \{0,+\}^k\}$ of arbitrary $[[n,k,d]]$ CSS codes.
 
 ## Synthesizing non-FT state preparation circuits
 

--- a/docs/StatePrep.md
+++ b/docs/StatePrep.md
@@ -14,7 +14,7 @@ mystnb:
 # Fault tolerant state preparation of Pauli eigenstates for CSS codes
 
 The QECC package contains functionality for synthesizing and simulating fault tolerant and non-fault tolerant state preparation circuits for Pauli eigenstates of CSS codes.
-Currently it supports synthesizing circuits for preparing the any logical state of the form $\{|s\rangle_L \mid s \in \{0,+\}^k\}$ of arbitrary $[[n,k,d]]$ CSS codes.
+Currently, it supports synthesizing circuits for preparing any logical Pauli eigenstate of the form $\{|s\rangle_L \mid s \in \{0,+\}^k\}$ of arbitrary $[[n,k,d]]$ CSS codes.
 
 ## Synthesizing non-FT state preparation circuits
 

--- a/docs/StatePrep.md
+++ b/docs/StatePrep.md
@@ -133,7 +133,7 @@ from mqt.qecc.circuit_synthesis import heuristic_prep_circuit
 from mqt.qecc.codes import SquareOctagonColorCode
 
 cc = SquareOctagonColorCode(5)
-cc_non_ft_sp = heuristic_prep_circuit(cc, zero_state=True, optimize_depth=True)
+cc_non_ft_sp = heuristic_prep_circuit(cc, state="all_zero", optimize_depth=True)
 
 cc_non_ft_sp.circ.draw(output="mpl", initial_state=True, scale=0.7)
 ```

--- a/scripts/ft_stateprep/eval/estimate_logical_error_rate.py
+++ b/scripts/ft_stateprep/eval/estimate_logical_error_rate.py
@@ -85,7 +85,7 @@ def main() -> None:
         if args.exact_circ:
             circ = gate_optimal_prep_circuit(code, zero_state=args.zero_state, max_timeout=600)
         else:
-            circ = heuristic_prep_circuit(code, zero_state=args.zero_state)
+            circ = heuristic_prep_circuit(code, zero_state="all_zero" if args.zero_state else "all_plus")
 
         assert circ is not None
         if args.naive_ver:

--- a/src/mqt/qecc/circuit_synthesis/simulation.py
+++ b/src/mqt/qecc/circuit_synthesis/simulation.py
@@ -94,7 +94,9 @@ class NoisyNDFTStatePrepSimulator(ABC):
         return noisy_circ
 
     def _build_noisy_gadget(self, noise: NoiseModel, p: float) -> stim.Circuit:
-        anc = heuristic_prep_circuit(self.code, zero_state=not self.zero_state).circ.to_stim_circuit()
+        anc = heuristic_prep_circuit(
+            self.code, state="all_zero" if not self.zero_state else "all_plus"
+        ).circ.to_stim_circuit()
         noisy_circ = noise.apply(self.circ)
 
         anc_qubits = list(range(noisy_circ.num_qubits, noisy_circ.num_qubits + anc.num_qubits))

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -200,7 +200,7 @@ def _build_state_prep_circuit_from_back(
 def heuristic_prep_circuit(
     code: CSSCode,
     optimize_depth: bool = True,
-    zero_state: bool = True,
+    zero_state: bool | str = True,
     *,
     rollout: int = 0,
     rollout_candidates: int = 10,
@@ -209,7 +209,7 @@ def heuristic_prep_circuit(
 
     Args:
         code: The CSS code to prepare the state for.
-        zero_state: If True, prepare the +1 eigenstate of the Z basis. If False, prepare the +1 eigenstate of the X basis.
+        zero_state: k-length string representing the logical state to prepare. If True, prepare the +1 eigenstate of the Z basis. If False, prepare the +1 eigenstate of the X basis.
         optimize_depth: If True, optimize the circuit for depth. If False, optimize for number of gates.
         rollout: The number of rollout steps to use in the heuristic synthesis. Higher values can lead to better circuits but also increase runtime.
         rollout_candidates: The number of candidates to consider in each rollout step. Higher values can lead to better circuits but also increase runtime.
@@ -219,9 +219,24 @@ def heuristic_prep_circuit(
     """
     logger.info("Starting heuristic state preparation.")
 
-    checks = code.Hx if zero_state else code.Hz
+    if isinstance(zero_state, bool):
+        checks = code.Hx if zero_state else code.Hz
+        type_ = "X" if zero_state else "Z"
+    else:
+        assert len(zero_state) == code.k, "Logical state must be a string of length k."
+        assert all(s in {"+", "0"} for s in zero_state), "Logical state must be a string of '+' and '0' characters."
+
+        x_indices = [i for i, state in enumerate(zero_state) if state == "+"]
+        z_indices = [i for i, state in enumerate(zero_state) if state == "0"]
+
+        if len(x_indices) <= len(z_indices):
+            checks = np.vstack((code.Hx, code.Lx[x_indices]))
+            type_ = "X"
+        else:
+            checks = np.vstack((code.Hz, code.Lz[z_indices]))
+            type_ = "Z"
+
     assert checks is not None
-    type_ = "X" if zero_state else "Z"
     config = SynthesisConfig(
         optimization_criterion="depth" if optimize_depth else "gates",
         rollout=rollout,

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -200,7 +200,7 @@ def _build_state_prep_circuit_from_back(
 def heuristic_prep_circuit(
     code: CSSCode,
     optimize_depth: bool = True,
-    zero_state: bool | str = True,
+    state: str = "all_zero",
     *,
     rollout: int = 0,
     rollout_candidates: int = 10,
@@ -209,7 +209,7 @@ def heuristic_prep_circuit(
 
     Args:
         code: The CSS code to prepare the state for.
-        zero_state: k-length string representing the logical state to prepare. If True, prepare the +1 eigenstate of the Z basis. If False, prepare the +1 eigenstate of the X basis.
+        state: k-length string representing the logical state to prepare. If "all_zero", prepare the +1 eigenstate of the Z basis. If "all_plus", prepare the +1 eigenstate of the X basis.
         optimize_depth: If True, optimize the circuit for depth. If False, optimize for number of gates.
         rollout: The number of rollout steps to use in the heuristic synthesis. Higher values can lead to better circuits but also increase runtime.
         rollout_candidates: The number of candidates to consider in each rollout step. Higher values can lead to better circuits but also increase runtime.
@@ -219,15 +219,18 @@ def heuristic_prep_circuit(
     """
     logger.info("Starting heuristic state preparation.")
 
-    if isinstance(zero_state, bool):
-        checks = code.Hx if zero_state else code.Hz
-        type_ = "X" if zero_state else "Z"
+    if state == "all_zero":
+        checks = code.Hx
+        type_ = "X"
+    elif state == "all_plus":
+        checks = code.Hz
+        type_ = "Z"
     else:
-        assert len(zero_state) == code.k, "Logical state must be a string of length k."
-        assert all(s in {"+", "0"} for s in zero_state), "Logical state must be a string of '+' and '0' characters."
+        assert len(state) == code.k, "Logical state must be a string of length k."
+        assert all(s in {"+", "0"} for s in state), "Logical state must be a string of '+' and '0' characters."
 
-        x_indices = [i for i, state in enumerate(zero_state) if state == "+"]
-        z_indices = [i for i, state in enumerate(zero_state) if state == "0"]
+        x_indices = [i for i, state in enumerate(state) if state == "+"]
+        z_indices = [i for i, state in enumerate(state) if state == "0"]
 
         if len(x_indices) <= len(z_indices):
             checks = np.vstack((code.Hx, code.Lx[x_indices]))

--- a/tests/circuit_synthesis/test_simulation.py
+++ b/tests/circuit_synthesis/test_simulation.py
@@ -51,7 +51,7 @@ def non_ft_steane_zero(steane_code: CSSCode) -> QuantumCircuit:
 @pytest.fixture
 def non_ft_steane_plus(steane_code: CSSCode) -> QuantumCircuit:
     """Return a non fault-tolerant Steane code state preparation circuit."""
-    return heuristic_prep_circuit(steane_code, zero_state=False).circ.to_qiskit_circuit()
+    return heuristic_prep_circuit(steane_code, state="all_plus").circ.to_qiskit_circuit()
 
 
 @pytest.fixture
@@ -71,7 +71,7 @@ def ft_steane_zero_naive(steane_code: CSSCode) -> QuantumCircuit:
 @pytest.fixture
 def ft_steane_plus(steane_code: CSSCode) -> QuantumCircuit:
     """Return a fault-tolerant Steane code state preparation circuit."""
-    circ = heuristic_prep_circuit(steane_code, zero_state=False)
+    circ = heuristic_prep_circuit(steane_code, state="all_plus")
     return gate_optimal_verification_circuit(circ, max_timeout=2)
 
 

--- a/tests/circuit_synthesis/test_stateprep.py
+++ b/tests/circuit_synthesis/test_stateprep.py
@@ -198,7 +198,7 @@ def test_plus_state_gate_optimal(code: str, request: pytest.FixtureRequest) -> N
 def test_plus_state_heuristic(code: str, request: pytest.FixtureRequest) -> None:
     """Test synthesis of the plus state."""
     code_ = request.getfixturevalue(code)
-    sp_circ_plus = heuristic_prep_circuit(code_, zero_state=False)
+    sp_circ_plus = heuristic_prep_circuit(code_, state="all_plus")
 
     assert sp_circ_plus is not None
 
@@ -212,7 +212,7 @@ def test_plus_state_heuristic(code: str, request: pytest.FixtureRequest) -> None
     assert eq_span(code_.Hz, sp_circ_plus.z_checks)
     assert eq_span(np.vstack((code_.Hx, code_.Lx)), sp_circ_plus.x_checks)
 
-    sp_circ_zero = heuristic_prep_circuit(code_, zero_state=True)
+    sp_circ_zero = heuristic_prep_circuit(code_, state="all_zero")
 
     if code_.is_self_dual():
         assert eq_span(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
@@ -351,7 +351,7 @@ def test_full_ft_heuristic_cc5(color_code_d5_sp: FaultyStatePrepCircuit) -> None
 @pytest.mark.parametrize("logical_state", ["00", "0+", "+0", "++"])
 def test_heuristic_custom_logical_state(logical_state: str, css_4_2_2_code: CSSCode) -> None:
     """Test preparation of custom logical states."""
-    sp_circ = heuristic_prep_circuit(css_4_2_2_code, zero_state=logical_state)
+    sp_circ = heuristic_prep_circuit(css_4_2_2_code, state=logical_state)
 
     plus = [i for i, state in enumerate(logical_state) if state == "+"]
     zero = [i for i, state in enumerate(logical_state) if state == "0"]
@@ -361,11 +361,11 @@ def test_heuristic_custom_logical_state(logical_state: str, css_4_2_2_code: CSSC
     assert eq_span(np.vstack((css_4_2_2_code.Hz, css_4_2_2_code.Lz[zero])), sp_circ.z_checks)
 
 
-@pytest.mark.parametrize(("logical_state", "equivalent_string"), [(True, "00"), (False, "++")])
-def test_heuristic_bool_str_compatibility(logical_state: bool, equivalent_string: str, css_4_2_2_code: CSSCode) -> None:
-    """Test preparation of custom logical states is still compatible with the old boolean interface."""
-    bool_circ = heuristic_prep_circuit(css_4_2_2_code, zero_state=logical_state)
-    str_circ = heuristic_prep_circuit(css_4_2_2_code, zero_state=equivalent_string)
+@pytest.mark.parametrize(("logical_state", "equivalent_string"), [("00", "all_zero"), ("++", "all_plus")])
+def test_heuristic_explicit_compatibility(logical_state: str, equivalent_string: str, css_4_2_2_code: CSSCode) -> None:
+    """Test preparation of custom logical states is compatible with the explicit string interface."""
+    bool_circ = heuristic_prep_circuit(css_4_2_2_code, state=logical_state)
+    str_circ = heuristic_prep_circuit(css_4_2_2_code, state=equivalent_string)
 
     assert eq_span(bool_circ.x_checks, str_circ.x_checks)
     assert eq_span(bool_circ.z_checks, str_circ.z_checks)

--- a/tests/circuit_synthesis/test_stateprep.py
+++ b/tests/circuit_synthesis/test_stateprep.py
@@ -348,6 +348,29 @@ def test_full_ft_heuristic_cc5(color_code_d5_sp: FaultyStatePrepCircuit) -> None
     assert circ_ver.num_nonlocal_gates() == n_cnots + circ.circ.num_cnots()
 
 
+@pytest.mark.parametrize("logical_state", ["00", "0+", "+0", "++"])
+def test_heuristic_custom_logical_state(logical_state: str, css_4_2_2_code: CSSCode) -> None:
+    """Test preparation of custom logical states."""
+    sp_circ = heuristic_prep_circuit(css_4_2_2_code, zero_state=logical_state)
+
+    plus = [i for i, state in enumerate(logical_state) if state == "+"]
+    zero = [i for i, state in enumerate(logical_state) if state == "0"]
+
+    assert sp_circ.num_qubits == css_4_2_2_code.n
+    assert eq_span(np.vstack((css_4_2_2_code.Hx, css_4_2_2_code.Lx[plus])), sp_circ.x_checks)
+    assert eq_span(np.vstack((css_4_2_2_code.Hz, css_4_2_2_code.Lz[zero])), sp_circ.z_checks)
+
+
+@pytest.mark.parametrize(("logical_state", "equivalent_string"), [(True, "00"), (False, "++")])
+def test_heuristic_bool_str_compatibility(logical_state: bool, equivalent_string: str, css_4_2_2_code: CSSCode) -> None:
+    """Test preparation of custom logical states is still compatible with the old boolean interface."""
+    bool_circ = heuristic_prep_circuit(css_4_2_2_code, zero_state=logical_state)
+    str_circ = heuristic_prep_circuit(css_4_2_2_code, zero_state=equivalent_string)
+
+    assert eq_span(bool_circ.x_checks, str_circ.x_checks)
+    assert eq_span(bool_circ.z_checks, str_circ.z_checks)
+
+
 # @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
 # def test_error_detection_code() -> None:
 #     """Test that different circuits are obtained when using an error detection code."""


### PR DESCRIPTION
## Description

The construction of a heuristic state preparation circuit was extended by adding the possibility of choosing an arbitrary input state, which can be a string of 0 and + (previously: only a choice between all $|0\rangle_L$ and all $|+\rangle_L$ possible) for the given code.

Assisted-by: GitHub Copilot through inline suggestions; Codex via GPT-5.5 as first reviewer (both reviewed by me)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qecc/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
