### PR TITLE
🛠️ Fix bugs regarding validity checks on input log. operators in StabilizerCode

### DIFF
--- a/src/mqt/qecc/codes/stabilizer_code.py
+++ b/src/mqt/qecc/codes/stabilizer_code.py
@@ -63,9 +63,9 @@ class StabilizerCode:
         self.distance = 1 if distance is None else distance  # default distance is 1
         self.compute_logical_ops()
         if z_logicals is not None:
-            self.z_logicals = self.get_generators(z_logicals)
+            self.z_logicals = self.get_generators(z_logicals, self.n)
         if x_logicals is not None:
-            self.x_logicals = self.get_generators(x_logicals)
+            self.x_logicals = self.get_generators(x_logicals, self.n)
 
         self._check_code_correct()
 

--- a/src/mqt/qecc/codes/stabilizer_code.py
+++ b/src/mqt/qecc/codes/stabilizer_code.py
@@ -236,6 +236,10 @@ class StabilizerCode:
             msg = "Number of logical X-operators must be at most the number of logical qubits."
             raise InvalidStabilizerCodeError(msg)
 
+        if self.z_logicals.shape[0] != self.x_logicals.shape[0]:
+            msg = "Number of logical Z-operators must be equal to the number of logical X-operators."
+            raise InvalidStabilizerCodeError(msg)
+
         if not self.z_logicals.all_commute(self.generators):
             msg = "Logical Z-operators must commute with the stabilizer generators."
             raise InvalidStabilizerCodeError(msg)
@@ -243,12 +247,16 @@ class StabilizerCode:
             msg = "Logical X-operators must commute with the stabilizer generators."
             raise InvalidStabilizerCodeError(msg)
 
-        commutations = (self.z_logicals.tableau @ self.x_logicals.tableau).matrix
-        if not np.all(np.sum(commutations, axis=1) == 1):
-            msg = "Every logical X-operator must anti-commute with exactly one logical Z-operator."
+        def commutation_matrix(m1: np.ndarray, m2: np.ndarray) -> np.ndarray:
+            n = m1.shape[1] // 2
+            return ((m1[:, :n] @ m2[:, n:].T) + (m1[:, n:] @ m2[:, :n].T)) % 2
+
+        commutations = commutation_matrix(self.z_logicals.tableau.matrix, self.x_logicals.tableau.matrix)
+        if not np.array_equal(commutations, np.eye(self.z_logicals.shape[0], dtype=np.int8)):
+            msg = "Every logical X-operator must anti-commute with exactly one logical Z-operator and vice versa."
             raise InvalidStabilizerCodeError(msg)
 
-        stabilizer_commutations = (self.generators.tableau @ self.generators.tableau).matrix
+        stabilizer_commutations = commutation_matrix(self.generators.tableau.matrix, self.generators.tableau.matrix)
         if not np.all(stabilizer_commutations == 0):
             msg = "Stabilizer generators must commute with each other."
             raise InvalidStabilizerCodeError(msg)

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -479,13 +479,19 @@ def test_invalid_pauli_strings() -> None:
 def test_no_x_logical() -> None:
     """Test that an error is raised if no X logical is provided when a Z logical is provided."""
     with pytest.raises(InvalidStabilizerCodeError):
-        StabilizerCode(["ZZZZ", "XXXX"], x_logicals=["XXII"])
+        StabilizerCode(["ZZZZ", "XXXX"], z_logicals=["XXII"])
 
 
 def test_no_z_logical() -> None:
     """Test that an error is raised if no Z logical is provided when an X logical is provided."""
     with pytest.raises(InvalidStabilizerCodeError):
-        StabilizerCode(["ZZZZ", "XXXX"], z_logicals=["ZZII"])
+        StabilizerCode(["ZZZZ", "XXXX"], x_logicals=["ZZII"])
+
+
+def test_not_compatible_logicals() -> None:
+    """Test that an error is raised if no Z logical is provided when an X logical is provided."""
+    with pytest.raises(InvalidStabilizerCodeError):
+        StabilizerCode([], n=2, z_logicals=["ZI", "IZ"], x_logicals=["XX", "ZZ"])
 
 
 def test_logicals_wrong_length() -> None:

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -518,6 +518,12 @@ def test_too_many_logicals() -> None:
         StabilizerCode(["ZZZZ", "XXXX"], z_logicals=["IZZI"], x_logicals=["XXII", "XXII", "XXII"])
 
 
+def test_empty_logicals() -> None:
+    """Test that an the case of empty logicals is handled gracefully."""
+    code = StabilizerCode(["XX", "ZZ"], z_logicals=[], x_logicals=[])
+    assert code.k == 0
+
+
 def test_code_equality() -> None:
     """Test equality of stabilizer codes."""
     # Equal codes


### PR DESCRIPTION
## Description

This PR fixes two explicit bugs in the handling of input logical operators for the initializer of `StabilizerCode`:
- unhandled crash (ValueError) when empty lists (valid input and valid state of a StabilizerCode) are passed; only the additional parameter `n` needed
- false acceptance of logical operator input with unequal number of `x_logicals` and `z_logicals`; only one additional check needed
- false acceptance of logical operator input with `x_logicals` and `z_logicals` not matching 1:1 in anti-commutation relation

 Another thing that PR does is strengthen the assumptions that the initializer enforces for the logical operators, which are implicitly used later (and enforced by the custom computation in `compute_logical_ops`). Namely, not only do the logical operations `x_logicals` and `z_logicals` have to match 1:1, but they also have to match according to their order.
 
 _Note:_ The helper `commutation_matrix` was introduced, as the result of the two relevant operations is semantically not a `SymplecticMatrix`.

Assisted by: GitHub Copilot through inline suggestions; Codex via GPT-5.5 as first reviewer (both reviewed by me)

Fixes #739

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qecc/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
