### PR TITLE
🐛 Fix qiskit_to_qsample CNOT operand encoding

### DIFF
--- a/src/mqt/qecc/circuit_synthesis/simulation_det.py
+++ b/src/mqt/qecc/circuit_synthesis/simulation_det.py
@@ -430,6 +430,6 @@ def qiskit_to_qsample(qiskit_circuit: QuantumCircuit) -> qs.Circuit:
         if len(qargs) == 1:
             qubits = {qiskit_circuit.qubits.index(qargs[0])}
         else:
-            qubits = {qiskit_circuit.qubits.index(q) for q in qargs}
+            qubits = {tuple(qiskit_circuit.qubits.index(q) for q in qargs)}
         custom_circuit.append({gate_name: qubits})
     return qs.Circuit(custom_circuit, noisy=True)


### PR DESCRIPTION
## Description

This PR fixes #765 .
I added a `tuple()` to the existing code snippet so that it provides the correct `{(control, target)}` structure to qsample for `CNOT` gates.

Updated code:
```
else:
    qubits = {tuple(qiskit_circuit.qubits.index(q) for q in qargs)}
```
## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

This PR and the issue it fixes uses no AI-assisted content.