### PR TITLE
🐛 Normalize CSS check-matrix dtype to int8

### DIFF
--- a/src/mqt/qecc/codes/core/css_code.py
+++ b/src/mqt/qecc/codes/core/css_code.py
@@ -39,6 +39,10 @@ class CSSCode(StabilizerCode):
         Lz: npt.NDArray[np.int8] | None = None,  # ruff:ignore[invalid-argument-name]
     ) -> None:
         """Initialize the code."""
+        # Check/logical matrices are binary GF(2) arrays and are normalized to int8 below (via
+        # ``np.asarray``/``np.array``). This keeps the whole code object dtype-consistent with the
+        # int8 type annotations; without it, dtypes such as uint8/int16/bool propagate through
+        # ``symplectic``/``Hx``/``Hz`` and break numba-dispatched synthesis (see issue #775).
         if Hx is None and Hz is None:
             if n is None:
                 msg = "If no check matrices are provided, the code size must be specified."
@@ -49,13 +53,13 @@ class CSSCode(StabilizerCode):
             self._check_valid_check_matrices(Hx, Hz)
             if Hx is not None:
                 inferred_n = Hx.shape[1]
-                hx = Hx
-                hz = Hz if Hz is not None else np.zeros((0, inferred_n), dtype=np.int8)
+                hx = np.asarray(Hx, dtype=np.int8)
+                hz = np.asarray(Hz, dtype=np.int8) if Hz is not None else np.zeros((0, inferred_n), dtype=np.int8)
             else:
                 assert Hz is not None
                 inferred_n = Hz.shape[1]
                 hx = np.zeros((0, inferred_n), dtype=np.int8)
-                hz = Hz
+                hz = np.asarray(Hz, dtype=np.int8)
 
         num_qubits = hx.shape[1]
         if n is not None and n != num_qubits:
@@ -68,8 +72,8 @@ class CSSCode(StabilizerCode):
             raise InvalidCSSCodeError(msg)
 
         if Lx is not None and Lz is not None:
-            lx = Lx.copy()
-            lz = Lz.copy()
+            lx = np.array(Lx, dtype=np.int8)
+            lz = np.array(Lz, dtype=np.int8)
         else:
             lx = CSSCode._compute_logical(hz, hx)
             lz = CSSCode._compute_logical(hx, hz)
@@ -191,7 +195,10 @@ class CSSCode(StabilizerCode):
             if Hx.shape[1] != Hz.shape[1]:
                 msg = "Check matrices must have the same number of columns"
                 raise InvalidCSSCodeError(msg)
-            if np.any(Hx @ Hz.T % 2 != 0):
+            # Cast to an integer dtype before the matmul: for boolean inputs ``@`` is a logical
+            # product (any overlap -> True), so the mod-2 orthogonality test would otherwise be
+            # wrong (see issue #775).
+            if np.any(Hx.astype(np.int64) @ Hz.astype(np.int64).T % 2 != 0):
                 msg = "The check matrices must be orthogonal"
                 raise InvalidCSSCodeError(msg)
 

--- a/src/mqt/qecc/codes/core/pauli.py
+++ b/src/mqt/qecc/codes/core/pauli.py
@@ -696,7 +696,11 @@ class CheckMatrix:
             msg = f"Check matrix type must be either 'X' or 'Z', got {pauli_type!r}."
             raise ValueError(msg)
         assert matrix.ndim == 2, "Matrix must be 2D."
-        self.matrix = matrix.copy()
+        # Normalize to int8 so downstream (numba-dispatched) routines always receive a supported
+        # dtype. Check matrices are binary GF(2) arrays, so int8 is lossless; without this, integer
+        # dtypes such as uint8/int16 propagate through and raise a numba "No matching definition"
+        # dispatch error (see issue #775).
+        self.matrix = np.array(matrix, dtype=np.int8)
         self.type = pauli_type
 
     def is_x_type(self) -> bool:

--- a/tests/codes/test_css_code.py
+++ b/tests/codes/test_css_code.py
@@ -85,6 +85,37 @@ def test_partial_logicals_rejected(steane_code_checks: tuple[npt.NDArray[np.int8
         CSSCode(distance=3, Hx=hx, Hz=hz, Lz=lx)
 
 
+@pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.bool_])
+def test_check_matrix_dtype_normalized(
+    dtype: npt.DTypeLike, steane_code_checks: tuple[npt.NDArray[np.int8], npt.NDArray[np.int8]]
+) -> None:
+    """Any binary check-matrix dtype yields a consistent int8 code (regression test for #775).
+
+    Non-int8 dtypes previously propagated into ``Hx``/``Hz`` and broke numba-dispatched synthesis
+    (uint8/int16) or the boolean-``@`` orthogonality check (bool).
+    """
+    hx, hz = steane_code_checks
+    code = CSSCode(distance=3, Hx=hx.astype(dtype), Hz=hz.astype(dtype))
+    assert code.Hx.dtype == np.int8
+    assert code.Hz.dtype == np.int8
+    # Downstream matmul must still compute the correct mod-2 syndrome regardless of input dtype.
+    error = np.zeros(code.n, dtype=np.int8)
+    error[0] = 1
+    np.testing.assert_array_equal(code.get_x_syndrome(error), hx[:, 0].astype(np.int8))
+
+
+def test_orthogonality_check_rejects_non_orthogonal_bool() -> None:
+    """Genuinely non-orthogonal boolean check matrices are still rejected (regression test for #775).
+
+    A boolean ``@`` computes a logical product, so the mod-2 orthogonality test must widen the dtype
+    to remain correct — without over-accepting non-orthogonal codes.
+    """
+    hx = np.array([[1, 1, 0]], dtype=np.bool_)
+    hz = np.array([[1, 0, 0]], dtype=np.bool_)
+    with pytest.raises(InvalidCSSCodeError, match="orthogonal"):
+        CSSCode(distance=1, Hx=hx, Hz=hz)
+
+
 @pytest.mark.parametrize("checks", ["steane_code_checks", "rep_code_checks", "rep_code_checks_reverse"])
 def test_logicals(checks: str, request: pytest.FixtureRequest) -> None:
     """Test the logical operators of the CSSCode class."""

--- a/tests/codes/test_pauli.py
+++ b/tests/codes/test_pauli.py
@@ -317,3 +317,16 @@ def test_check_matrix() -> None:
     assert hash(x_checks) == hash(x_checks.copy())
     assert x_checks.equ_span(z_checks)
     assert repr(x_checks) == "CheckMatrix(type=X, matrix=\n[[1 0]\n [0 1]])"
+
+
+@pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.bool_])
+def test_check_matrix_normalizes_dtype(dtype: npt.DTypeLike) -> None:
+    """CheckMatrix normalizes any binary integer dtype to int8 (regression test for #775).
+
+    Non-int8 dtypes (e.g. uint8/int16) previously propagated into numba-dispatched synthesis
+    routines and raised a "No matching definition" dispatch error.
+    """
+    matrix = np.eye(2, dtype=dtype)
+    checks = CheckMatrix(matrix, "X")
+    assert checks.matrix.dtype == np.int8
+    assert_array_equal(checks.matrix, np.eye(2, dtype=np.int8))


### PR DESCRIPTION
Fixes #775.

Passing check matrices with a "wrong" integer dtype to `CSSCode` blew up later on. `uint8`/`int16` parity checks crashed the heuristic state-prep synthesis with a numba `No matching definition` error (the jitted scorer is only compiled for int8/int32/int64), and `bool` matrices were quietly mishandled because numpy's boolean `@` is a logical product, so the CSS orthogonality check computed the wrong result.

Rather than teach numba about every dtype, I normalize the check/logical matrices to int8 at construction — they're binary GF(2) arrays so it's lossless, and it keeps the whole code object consistent with the existing int8 annotations. I also widened the orthogonality check to an integer accumulator so `bool` inputs are validated correctly (`CheckMatrix` gets the same int8 normalization).

Added regression tests covering all the integer dtypes plus bool, and confirming genuinely non-orthogonal codes are still rejected.